### PR TITLE
BAH-2346 | Removing close button

### DIFF
--- a/src/components/consultation-notes/consultation-notes.test.tsx
+++ b/src/components/consultation-notes/consultation-notes.test.tsx
@@ -36,20 +36,4 @@ describe('Floating Button and Consultation Pad', () => {
       ).toBeInTheDocument()
     })
   })
-
-  it('should show consultation pad button when consultation pad is closed', async () => {
-    render(<ConsultationNotes />)
-
-    const consultationPadButtonName = {
-      name: /Consultation Pad/i,
-    }
-    await userEvent.click(screen.getByRole('button', consultationPadButtonName))
-    await userEvent.click(screen.getByLabelText('close'))
-
-    await waitFor(() => {
-      expect(
-        screen.getByRole('button', consultationPadButtonName),
-      ).toBeInTheDocument()
-    })
-  })
 })

--- a/src/components/consultation-pad/consultation-pad.test.tsx
+++ b/src/components/consultation-pad/consultation-pad.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import {ConsultationPad} from './consultation-pad'
 
 describe('Consultation Pad', () => {
-  it('should show consultation notes heading, minimize icon, close icon, start mic and save button when consultation pad component is rendered', () => {
+  it('should show consultation notes heading, minimize icon, start mic and save button when consultation pad component is rendered', () => {
     render(
       <ConsultationPad
         setShowConsultationPad={jest.fn()}
@@ -16,7 +16,6 @@ describe('Consultation Pad', () => {
     expect(screen.getByRole('heading', {name: /Consultation Notes/i}))
     expect(screen.getByText('Consultation Notes')).toBeInTheDocument()
     expect(screen.getByLabelText('minimizeIcon')).toBeInTheDocument()
-    expect(screen.getByLabelText('close')).toBeInTheDocument()
     expect(screen.getByLabelText('Start Mic')).toBeInTheDocument()
   })
 })

--- a/src/components/consultation-pad/consultation-pad.tsx
+++ b/src/components/consultation-pad/consultation-pad.tsx
@@ -8,17 +8,15 @@ export function ConsultationPad({
   setShowConsultationPad,
   setSavedNotes,
 }) {
-  const clickCloseButton = useCallback(() => setShowConsultationPad(false), [])
+  const clickMinimizeIcon = useCallback(() => setShowConsultationPad(false), [])
 
   return (
     <DraggableBox
       heading="Consultation Notes"
-      handleClose={clickCloseButton}
-      setConsultationText={setConsultationText}
-      setSavedNotes={setSavedNotes}
+      handleMinimize={clickMinimizeIcon}
     >
       <ConsultationPadContents
-        closeConsultationPad={clickCloseButton}
+        closeConsultationPad={clickMinimizeIcon}
         consultationText={consultationText}
         setConsultationText={setConsultationText}
         setSavedNotes={setSavedNotes}

--- a/src/components/draggable-box/draggable-box.scss
+++ b/src/components/draggable-box/draggable-box.scss
@@ -10,17 +10,12 @@
     z-index: 10;
   }
 
-  .closeIcon{
-    width: 1.5rem;
-    block-size: auto;
-    cursor: pointer;
-
-  }
   .minimizeIcon{
     width: 1.5rem;
     block-size: auto;
     cursor: pointer;
   }
+  
   .heading{
     display: flex;
     justify-content: space-between;

--- a/src/components/draggable-box/draggable-box.test.tsx
+++ b/src/components/draggable-box/draggable-box.test.tsx
@@ -5,23 +5,18 @@ import userEvent from '@testing-library/user-event'
 
 describe('Draggable Box', () => {
   const children = <h1>hello</h1>
-  const handleClose = jest.fn()
-  const setConsultationText = jest.fn()
-  const setSavedNotes = jest.fn()
-  it('should show heading, minimize icon, close icon and child components when draggable box is rendered', () => {
+  const handleMinimize = jest.fn()
+  it('should show heading, minimize icon and child components when draggable box is rendered', () => {
     render(
       <DraggableBox
         heading={'Consultation notes'}
-        handleClose={handleClose}
-        setConsultationText={setConsultationText}
-        setSavedNotes={setSavedNotes}
+        handleMinimize={handleMinimize}
       >
         {children}
       </DraggableBox>,
     )
     expect(screen.getByRole('heading', {name: /Consultation Notes/i}))
     expect(screen.getByLabelText('minimizeIcon')).toBeInTheDocument()
-    expect(screen.getByLabelText('close')).toBeInTheDocument()
     expect(screen.getByText('hello')).toBeInTheDocument()
   })
 
@@ -29,30 +24,12 @@ describe('Draggable Box', () => {
     render(
       <DraggableBox
         heading={'Consultation notes'}
-        handleClose={handleClose}
-        setConsultationText={setConsultationText}
-        setSavedNotes={setSavedNotes}
+        handleMinimize={handleMinimize}
       >
         {children}
       </DraggableBox>,
     )
     await userEvent.click(screen.getByLabelText('minimizeIcon'))
-    expect(handleClose).toBeCalled()
-  })
-
-  it('should close draggable box when clicked on close icon', async () => {
-    render(
-      <DraggableBox
-        heading={'Consultation notes'}
-        handleClose={handleClose}
-        setConsultationText={setConsultationText}
-        setSavedNotes={setSavedNotes}
-      >
-        {children}
-      </DraggableBox>,
-    )
-    await userEvent.click(screen.getByLabelText('close'))
-    expect(handleClose).toBeCalled()
-    expect(setConsultationText).toHaveBeenCalledWith('')
+    expect(handleMinimize).toBeCalled()
   })
 })

--- a/src/components/draggable-box/draggable-box.tsx
+++ b/src/components/draggable-box/draggable-box.tsx
@@ -1,42 +1,22 @@
 import React, {useCallback} from 'react'
 import styles from './draggable-box.scss'
 import Draggable from 'react-draggable'
-import {Close, Subtract} from '@carbon/icons-react'
+import {Subtract} from '@carbon/icons-react'
 
-export function DraggableBox({
-  children,
-  heading,
-  handleClose,
-  setConsultationText,
-  setSavedNotes,
-}) {
+export function DraggableBox({children, heading, handleMinimize}) {
   const clickMinimizeIcon = useCallback(() => {
-    handleClose()
-  }, [])
-
-  const clickCloseIcon = useCallback(() => {
-    setConsultationText('')
-    setSavedNotes('')
-    handleClose()
+    handleMinimize()
   }, [])
 
   const renderConsultationHeader = () => {
     return (
       <div className={styles.heading}>
         <h4>{heading}</h4>
-        <div>
-          <Subtract
-            aria-label="minimizeIcon"
-            className={styles.minimizeIcon}
-            onClick={clickMinimizeIcon}
-          />
-
-          <Close
-            aria-label="close"
-            className={styles.closeIcon}
-            onClick={clickCloseIcon}
-          />
-        </div>
+        <Subtract
+          aria-label="minimizeIcon"
+          className={styles.minimizeIcon}
+          onClick={clickMinimizeIcon}
+        />
       </div>
     )
   }


### PR DESCRIPTION
## Requirements

- [x] This PR has a proper title that briefly describes the work done
- [x] I have squashed / amended the comments to make it more redable
- [x] I have included link to all the JIRA ticket('s)
- [x] I wrote the code as a pair or atleast performed a self-review of my own code
- [ ] I have updated the documentation on [Bahmni Wiki](https://bahmni.atlassian.net/wiki/spaces/BAH/overview) or [README](https://github.com/Bahmni/speech-assistant-frontend/blob/main/README.md) (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Summary
 Removing close button and its functionality which is redundant after having minimize
Ensuring “save notes” button closes the box ? ( Do we need to close it after saving) . I think we can . For the time being it would indicate that the notes have been saved 

## Screenshots
<img width="1952" alt="image" src="https://user-images.githubusercontent.com/108812690/193045097-db9d8647-1e38-484d-980f-ea27b965f046.png">


## JIRA tickets
https://bahmni.atlassian.net/browse/BAH-2346
