### PR TITLE
fix staging notes for minimize button

### DIFF
--- a/src/components/bahmni/bahmni-save-button-listener/save-button-listener.ts
+++ b/src/components/bahmni/bahmni-save-button-listener/save-button-listener.ts
@@ -15,10 +15,10 @@ const onBahmniSaveButtonClick = (
   closeConsultationPad,
   setSavedNotes,
 ) => {
+  closeConsultationPad()
   setTimeout(() => {
     saveConsultationNotes(consultationNotes, patientDetails)
     setSavedNotes(consultationNotes)
-    closeConsultationPad()
   }, bahmniSaveButtonResponseTime)
 }
 

--- a/src/components/consultation-pad/consultation-pad.test.tsx
+++ b/src/components/consultation-pad/consultation-pad.test.tsx
@@ -1,8 +1,13 @@
-import {render, screen} from '@testing-library/react'
+import {render, screen, waitFor} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import React from 'react'
+import SocketConnection from '../../utils/socket-connection/socket-connection'
 import {ConsultationPad} from './consultation-pad'
 
+jest.mock('../../utils/socket-connection/socket-connection')
+
 describe('Consultation Pad', () => {
+  afterEach(() => jest.clearAllMocks())
   it('should show consultation notes heading, minimize icon, start mic and save button when consultation pad component is rendered', () => {
     render(
       <ConsultationPad
@@ -17,5 +22,96 @@ describe('Consultation Pad', () => {
     expect(screen.getByText('Consultation Notes')).toBeInTheDocument()
     expect(screen.getByLabelText('minimizeIcon')).toBeInTheDocument()
     expect(screen.getByLabelText('Start Mic')).toBeInTheDocument()
+  })
+  it('should update consultation notes with recorded text when clicked on minimize icon without stopping the recording', async () => {
+    let consultationText = ''
+    const setConsultationText = jest.fn()
+    setConsultationText.mockImplementation(value => (consultationText = value))
+
+    const mockSocketConnection = {
+      handleStart: jest.fn(),
+      handleStop: jest.fn(),
+    }
+    ;(SocketConnection as jest.Mock).mockImplementation(
+      () => mockSocketConnection,
+    )
+
+    const {unmount} = render(
+      <ConsultationPad
+        setShowConsultationPad={jest.fn()}
+        consultationText={consultationText}
+        setConsultationText={setConsultationText}
+        setSavedNotes={jest.fn()}
+      />,
+    )
+
+    const mockOnIncomingMessage = (SocketConnection as jest.Mock).mock
+      .calls[0][1]
+    const mockOnRecording = (SocketConnection as jest.Mock).mock.calls[0][2]
+
+    expect(SocketConnection).toHaveBeenCalled()
+
+    const start = screen.getByLabelText('Start Mic')
+    expect(start).toBeInTheDocument()
+    userEvent.click(start)
+
+    await waitFor(() => {
+      mockOnRecording(true)
+
+      mockOnIncomingMessage('Notes')
+
+      expect(screen.getByLabelText('Stop Mic')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByLabelText('minimizeIcon'))
+    unmount()
+    await waitFor(() => {
+      expect(consultationText).toBe('Notes')
+    })
+  })
+
+  it('should append recorded text with consultation notes when clicked on minimize icon without stopping the recording', async () => {
+    let consultationText = 'Consultation'
+    const setConsultationText = jest.fn()
+    setConsultationText.mockImplementation(value => (consultationText = value))
+
+    const mockSocketConnection = {
+      handleStart: jest.fn(),
+      handleStop: jest.fn(),
+    }
+    ;(SocketConnection as jest.Mock).mockImplementation(
+      () => mockSocketConnection,
+    )
+    const {unmount} = render(
+      <ConsultationPad
+        setShowConsultationPad={jest.fn()}
+        consultationText={consultationText}
+        setConsultationText={setConsultationText}
+        setSavedNotes={jest.fn()}
+      />,
+    )
+
+    const mockOnIncomingMessage = (SocketConnection as jest.Mock).mock
+      .calls[0][1]
+    const mockOnRecording = (SocketConnection as jest.Mock).mock.calls[0][2]
+    expect(SocketConnection).toHaveBeenCalled()
+
+    const start = screen.getByLabelText('Start Mic')
+    expect(start).toBeInTheDocument()
+    userEvent.click(start)
+
+    await waitFor(() => {
+      mockOnRecording(true)
+
+      mockOnIncomingMessage('Notes')
+
+      expect(screen.getByLabelText('Stop Mic')).toBeInTheDocument()
+    })
+
+    await userEvent.click(screen.getByLabelText('minimizeIcon'))
+    unmount()
+    await waitFor(() => {
+      expect(consultationText).toBe('Consultation Notes')
+    })
   })
 })


### PR DESCRIPTION
## Requirements

- [x] This PR has a proper title that briefly describes the work done
- [x] I have squashed / amended the comments to make it more redable
- [x] I have included link to all the JIRA ticket('s)
- [x] I wrote the code as a pair or atleast performed a self-review of my own code
- [ ] I have updated the documentation on [Bahmni Wiki](https://bahmni.atlassian.net/wiki/spaces/BAH/overview) or [README](https://github.com/Bahmni/speech-assistant-frontend/blob/main/README.md) (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Summary
When the user clicks in minimize and opens the box again, the recorded notes should be staged.
Also, the recording should be paused when the user clicks on minimize.

## JIRA tickets
https://bahmni.atlassian.net/browse/BAH-2448

