### PR TITLE
BAH-2394 | Fetching saved notes in the consultation notes box

### DIFF
--- a/src/__mocks__/activeVisitWithActiveEncountersAndWithoutConsultationObs.mock.ts
+++ b/src/__mocks__/activeVisitWithActiveEncountersAndWithoutConsultationObs.mock.ts
@@ -1,4 +1,4 @@
-export const mockVisitResponseWithActiveEncounter = {
+export const mockVisitResponseWithActiveEncounterWithoutConsultationObs = {
   results: [
     {
       uuid: '8281dd37-45c0-4a45-a939-ecb95fdb6ed7',
@@ -63,19 +63,7 @@ export const mockVisitResponseWithActiveEncounter = {
               },
             ],
           },
-          obs: [
-            {
-              uuid: '8dd4d632-ec99-4056-b6dc-d489f1dc5f30',
-              display: 'Consultation Note: Saving Notes',
-              links: [
-                {
-                  rel: 'self',
-                  uri: 'http://localhost/openmrs/ws/rest/v1/obs/8dd4d632-ec99-4056-b6dc-d489f1dc5f30',
-                  resourceAlias: 'obs',
-                },
-              ],
-            },
-          ],
+          obs: [],
           orders: [
             {
               uuid: 'e1a5fb85-43c9-4436-9e14-e1b18a50eefc',

--- a/src/__mocks__/updateObsResponse.mock.ts
+++ b/src/__mocks__/updateObsResponse.mock.ts
@@ -1,0 +1,73 @@
+export const updateObsResponse = {
+  uuid: '3a4515ab-7b25-40aa-9cae-ceb6147a760f',
+  display: 'Consultation Note: Saving Notes',
+  concept: {
+    uuid: '81d6e852-3f10-11e4-adec-0800271c1b75',
+    display: 'Consultation Note',
+    links: [
+      {
+        rel: 'self',
+        uri: 'http://localhost/openmrs/ws/rest/v1/concept/81d6e852-3f10-11e4-adec-0800271c1b75',
+        resourceAlias: 'concept',
+      },
+    ],
+  },
+  person: {
+    uuid: 'a751f0da-39ab-45a3-db52-21706f5ed201',
+    display: 'GAN203011 - Test Con',
+    links: [
+      {
+        rel: 'self',
+        uri: 'http://localhost/openmrs/ws/rest/v1/patient/a751f0da-39ab-45a3-db52-21706f5ed201',
+        resourceAlias: 'patient',
+      },
+    ],
+  },
+  obsDatetime: '2022-10-17T07:46:53.000+0000',
+  accessionNumber: null,
+  obsGroup: null,
+  valueCodedName: null,
+  groupMembers: null,
+  comment: null,
+  location: {
+    uuid: 'baf7bd38-d225-11e4-9c67-080027b662ec',
+    display: 'General Ward',
+    links: [
+      {
+        rel: 'self',
+        uri: 'http://localhost/openmrs/ws/rest/v1/location/baf7bd38-d225-11e4-9c67-080027b662ec',
+        resourceAlias: 'location',
+      },
+    ],
+  },
+  order: null,
+  encounter: {
+    uuid: 'ea1e8ffa-bfe4-4939-88fd-3accf1ed7e05',
+    display: 'Consultation 10/17/2022',
+    links: [
+      {
+        rel: 'self',
+        uri: 'http://localhost/openmrs/ws/rest/v1/encounter/ea1e8ffa-bfe4-4939-88fd-3accf1ed7e05',
+        resourceAlias: 'encounter',
+      },
+    ],
+  },
+  voided: false,
+  value: 'Saving Notes',
+  valueModifier: null,
+  formFieldPath: null,
+  formFieldNamespace: null,
+  links: [
+    {
+      rel: 'self',
+      uri: 'http://localhost/openmrs/ws/rest/v1/obs/3a4515ab-7b25-40aa-9cae-ceb6147a760f',
+      resourceAlias: 'obs',
+    },
+    {
+      rel: 'full',
+      uri: 'http://localhost/openmrs/ws/rest/v1/obs/3a4515ab-7b25-40aa-9cae-ceb6147a760f?v=full',
+      resourceAlias: 'obs',
+    },
+  ],
+  resourceVersion: '1.11',
+}

--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -100,7 +100,7 @@ describe('Speech Assistant App', () => {
     expect(screen.getByRole('textbox')).toHaveValue('Saving Notes')
   })
 
-  it('should not show consultation pad button when there is no active visits for the patient in the set location', async () => {
+  it('should not show consultation pad button when there is no active visits for the patient in the set location',() => {
     Object.defineProperty(window, 'location', {
       value: {
         href: testSearchUrl,
@@ -115,7 +115,7 @@ describe('Speech Assistant App', () => {
 
     render(<App />)
 
-    await act(() => {
+    act(() => {
       window.location.href = testUrlWithPatientId
       window.dispatchEvent(new HashChangeEvent('hashchange'))
     })

--- a/src/components/active-consultation/active-consultation.test.tsx
+++ b/src/components/active-consultation/active-consultation.test.tsx
@@ -8,10 +8,20 @@ import ActiveConsultation from './active-consultation'
 
 describe('Active Consultation', () => {
   it('should not show consultation pad button when patient has no active visit', () => {
-    const mockPatientDetails: PatientDetails = null
+    const mockPatientDetails: PatientDetails = {
+      patientUuid: 'abc',
+      locationUuid: 'def',
+      isActiveVisit: false,
+    }
+
+    const value = {
+      patientDetails: mockPatientDetails,
+      savedConsultationNotes: '',
+      setSavedConsultationNotes: jest.fn(),
+    }
 
     render(
-      <ConsultationContext.Provider value={mockPatientDetails}>
+      <ConsultationContext.Provider value={value}>
         <ActiveConsultation />
       </ConsultationContext.Provider>,
     )
@@ -30,8 +40,13 @@ describe('Active Consultation', () => {
       isActiveVisit: true,
     }
 
+    const value = {
+      patientDetails: mockPatientDetails,
+      savedConsultationNotes: '',
+      setSavedConsultationNotes: jest.fn(),
+    }
     render(
-      <ConsultationContext.Provider value={mockPatientDetails}>
+      <ConsultationContext.Provider value={value}>
         <ActiveConsultation />
       </ConsultationContext.Provider>,
     )

--- a/src/components/active-consultation/active-consultation.tsx
+++ b/src/components/active-consultation/active-consultation.tsx
@@ -1,11 +1,15 @@
-import React, {useContext} from 'react'
-import {ConsultationContext} from '../../context/consultation-context'
+import React from 'react'
+import {
+  PatientDetails,
+  usePatientDetails,
+} from '../../context/consultation-context'
 import ConsultationNotes from '../consultation-notes/consultation-notes'
 
 const checkActiveVisit = patientDetails => patientDetails?.isActiveVisit
 
 function ActiveConsultation() {
-  const patientDetails = useContext(ConsultationContext)
+  const patientDetails: PatientDetails = usePatientDetails()
+
   return (
     checkActiveVisit(patientDetails) && (
       <div id="sa-consultation">

--- a/src/components/consultation-notes/consultation-notes.test.tsx
+++ b/src/components/consultation-notes/consultation-notes.test.tsx
@@ -1,12 +1,26 @@
 import {render, screen, waitFor} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
+import {
+  ConsultationContext,
+  PatientDetails,
+} from '../../context/consultation-context'
 import ConsultationNotes from './consultation-notes'
 
 describe('Floating Button and Consultation Pad', () => {
   it('should show consultation pad when consultation pad button is clicked', async () => {
-    render(<ConsultationNotes />)
+    const mockPatientDetails: PatientDetails = null
 
+    const value = {
+      patientDetails: mockPatientDetails,
+      savedConsultationNotes: '',
+      setSavedConsultationNotes: jest.fn(),
+    }
+    render(
+      <ConsultationContext.Provider value={value}>
+        <ConsultationNotes />
+      </ConsultationContext.Provider>,
+    )
     const consultationPadButtonName = {
       name: 'Notes',
     }
@@ -22,7 +36,18 @@ describe('Floating Button and Consultation Pad', () => {
   })
 
   it('should show consultation pad button when minimize icon is clicked', async () => {
-    render(<ConsultationNotes />)
+    const mockPatientDetails: PatientDetails = null
+
+    const value = {
+      patientDetails: mockPatientDetails,
+      savedConsultationNotes: '',
+      setSavedConsultationNotes: jest.fn(),
+    }
+    render(
+      <ConsultationContext.Provider value={value}>
+        <ConsultationNotes />
+      </ConsultationContext.Provider>,
+    )
 
     const consultationPadButtonName = {
       name: /Notes/i,

--- a/src/components/consultation-notes/consultation-notes.tsx
+++ b/src/components/consultation-notes/consultation-notes.tsx
@@ -1,23 +1,25 @@
 import React, {useState} from 'react'
+import {useSavedConsultationNotes} from '../../context/consultation-context'
 import {ConsultationPad} from '../consultation-pad/consultation-pad'
 import {FloatingConsultationButton} from '../floating-consultation-button/floating-consultation-button'
 
 function ConsultationNotes() {
   const [showConsultationPad, setShowConsultationPad] = useState(false)
-  const [consultationText, setConsultationText] = useState('')
-  const [savedNotes, setSavedNotes] = useState('')
+  const {savedConsultationNotes} = useSavedConsultationNotes()
+  const [consultationText, setConsultationText] = useState(
+    savedConsultationNotes,
+  )
 
   return showConsultationPad ? (
     <ConsultationPad
       consultationText={consultationText}
       setConsultationText={setConsultationText}
       setShowConsultationPad={setShowConsultationPad}
-      setSavedNotes={setSavedNotes}
     />
   ) : (
     <FloatingConsultationButton
       isUnsavedNotesPresent={
-        consultationText != savedNotes && consultationText != ''
+        consultationText != savedConsultationNotes && consultationText != ''
       }
       setShowConsultationPad={setShowConsultationPad}
     />

--- a/src/components/consultation-pad-contents/consultation-pad-contents.resources.ts
+++ b/src/components/consultation-pad-contents/consultation-pad-contents.resources.ts
@@ -60,7 +60,7 @@ export const saveObsData = async (
   postApiCall(saveNotesUrl, body).then(response => response.json())
 }
 
-export const updateObsData = async (obsUuid, consultationText) => {
+export const updateObsData = (obsUuid, consultationText) => {
   const body = {value: consultationText}
   postApiCall(updateObsUrl(obsUuid), body).then(response => response.json())
 }

--- a/src/components/consultation-pad-contents/consultation-pad-contents.resources.ts
+++ b/src/components/consultation-pad-contents/consultation-pad-contents.resources.ts
@@ -1,5 +1,14 @@
 import {postApiCall, getApiCall} from '../../utils/api-utils'
-import {saveNotesUrl, conceptUrl, customVisitUrl} from '../../utils/constants'
+import {
+  saveNotesUrl,
+  conceptUrl,
+  customVisitUrl,
+  updateObsUrl,
+} from '../../utils/constants'
+import {
+  getActiveConsultationEncounter,
+  getConsultationObs,
+} from '../../utils/encounter-details/encounter-details'
 
 interface ObsType {
   person: string
@@ -28,31 +37,6 @@ const requestbody = (
   }
 }
 
-const MILLISECOND_TO_MINUTE_CONVERSION_FACTOR = 60000
-const SIXTY_MINUTES = 60
-
-const isConsultationEncounterActive = consultationEncounter => {
-  const consultationEncounterDateTime = new Date(
-    consultationEncounter.encounterDatetime,
-  )
-  const currentDatetime = new Date()
-
-  const timeDifferenceInMinutes =
-    (currentDatetime.getTime() - consultationEncounterDateTime.getTime()) /
-    MILLISECOND_TO_MINUTE_CONVERSION_FACTOR
-
-  return timeDifferenceInMinutes < SIXTY_MINUTES
-}
-
-export const getEncounters = async patientDetails => {
-  const encounters = await getApiCall(
-    customVisitUrl(patientDetails.patientUuid, patientDetails.locationUuid),
-  )
-  return encounters?.results?.length > 0
-    ? encounters?.results[0]?.encounters
-    : null
-}
-
 export const saveObsData = async (
   consultationText,
   patientUuid,
@@ -76,21 +60,35 @@ export const saveObsData = async (
   postApiCall(saveNotesUrl, body).then(response => response.json())
 }
 
+export const updateObsData = async (obsUuid, consultationText) => {
+  const body = {value: consultationText}
+  postApiCall(updateObsUrl(obsUuid), body).then(response => response.json())
+}
+
 export const saveConsultationNotes = async (
   consultationText,
   patientDetails,
 ) => {
-  const encounters = await getEncounters(patientDetails)
-  const consultationActiveEncounter = encounters?.find(
-    encounter =>
-      encounter.encounterType.display == 'Consultation' &&
-      isConsultationEncounterActive(encounter),
+  const visitResponse = await getApiCall(
+    customVisitUrl(patientDetails.patientUuid, patientDetails.locationUuid),
   )
-  if (consultationActiveEncounter)
-    saveObsData(
-      consultationText,
-      patientDetails.patientUuid,
-      patientDetails.location,
-      consultationActiveEncounter.uuid,
-    )
+
+  const consultationActiveEncounter = await getActiveConsultationEncounter(
+    visitResponse,
+  )
+
+  if (consultationActiveEncounter) {
+    const consultationObs = getConsultationObs(consultationActiveEncounter)
+    if (consultationObs) {
+      const obsUuid = consultationObs.uuid
+      updateObsData(obsUuid, consultationText)
+    } else {
+      saveObsData(
+        consultationText,
+        patientDetails.patientUuid,
+        patientDetails.location,
+        consultationActiveEncounter.uuid,
+      )
+    }
+  }
 }

--- a/src/components/consultation-pad-contents/consultation-pad-contents.test.tsx
+++ b/src/components/consultation-pad-contents/consultation-pad-contents.test.tsx
@@ -9,10 +9,13 @@ import SocketConnection from '../../utils/socket-connection/socket-connection'
 import {mockConceptResponse} from '../../__mocks__/conceptResponse.mock'
 import {mockObsResponse} from '../../__mocks__/obsResponse.mock'
 import {customVisitUrl} from '../../utils/constants'
-import {mockVisitResponseWithActiveEncounter} from '../../__mocks__/activeVisitWithActiveEncounters.mock'
+
 import {mockVisitResponseWithInactiveEncounter} from '../../__mocks__/activeVisitWithInactiveEncounters.mock'
 import {ConsultationPadContents} from './consultation-pad-contents'
 import {mockVisitResponseWithNoEncounter} from '../../__mocks__/activeVisitWithNoEncounter.mock'
+import {mockVisitResponseWithActiveEncounterWithoutConsultationObs} from '../../__mocks__/activeVisitWithActiveEncountersAndWithoutConsultationObs.mock'
+import {mockVisitResponseWithActiveEncounter} from '../../__mocks__/activeVisitWithActiveEncounters.mock'
+import {updateObsResponse} from '../../__mocks__/updateObsResponse.mock'
 
 jest.mock('../../utils/socket-connection/socket-connection')
 
@@ -20,16 +23,28 @@ describe('Consultation Pad Contents', () => {
   afterEach(() => jest.clearAllMocks())
   const handleClose = jest.fn()
   const setConsultationText = jest.fn()
-  const setSavedNotes = jest.fn()
 
   it('should show the textbox, start mic and save button when consultation pad contents component is rendered', () => {
+    const mockPatientDetails: PatientDetails = {
+      patientUuid: 'abc',
+      locationUuid: 'def',
+      isActiveVisit: true,
+    }
+
+    const value = {
+      patientDetails: mockPatientDetails,
+      savedConsultationNotes: '',
+      setSavedConsultationNotes: jest.fn(),
+    }
     render(
-      <ConsultationPadContents
-        closeConsultationPad={handleClose}
-        consultationText={''}
-        setConsultationText={setConsultationText}
-        setSavedNotes={setSavedNotes}
-      />,
+      <ConsultationContext.Provider value={value}>
+        <ConsultationPadContents
+          closeConsultationPad={handleClose}
+          consultationText={''}
+          setConsultationText={setConsultationText}
+        />
+        ,
+      </ConsultationContext.Provider>,
     )
 
     expect(screen.getByRole('textbox')).toBeInTheDocument()
@@ -49,13 +64,27 @@ describe('Consultation Pad Contents', () => {
     ;(SocketConnection as jest.Mock).mockImplementation(
       () => mockSocketConnection,
     )
+
+    const mockPatientDetails: PatientDetails = {
+      patientUuid: 'abc',
+      locationUuid: 'def',
+      isActiveVisit: true,
+    }
+
+    const value = {
+      patientDetails: mockPatientDetails,
+      savedConsultationNotes: '',
+      setSavedConsultationNotes: jest.fn(),
+    }
     render(
-      <ConsultationPadContents
-        closeConsultationPad={handleClose}
-        consultationText={''}
-        setConsultationText={setConsultationText}
-        setSavedNotes={setSavedNotes}
-      />,
+      <ConsultationContext.Provider value={value}>
+        <ConsultationPadContents
+          closeConsultationPad={handleClose}
+          consultationText={''}
+          setConsultationText={setConsultationText}
+        />
+        ,
+      </ConsultationContext.Provider>,
     )
 
     const mockOnRecording = (SocketConnection as jest.Mock).mock.calls[0][2]
@@ -80,13 +109,26 @@ describe('Consultation Pad Contents', () => {
     ;(SocketConnection as jest.Mock).mockImplementation(
       () => mockSocketConnection,
     )
+    const mockPatientDetails: PatientDetails = {
+      patientUuid: 'abc',
+      locationUuid: 'def',
+      isActiveVisit: true,
+    }
+
+    const value = {
+      patientDetails: mockPatientDetails,
+      savedConsultationNotes: '',
+      setSavedConsultationNotes: jest.fn(),
+    }
     render(
-      <ConsultationPadContents
-        closeConsultationPad={handleClose}
-        consultationText={''}
-        setConsultationText={setConsultationText}
-        setSavedNotes={setSavedNotes}
-      />,
+      <ConsultationContext.Provider value={value}>
+        <ConsultationPadContents
+          closeConsultationPad={handleClose}
+          consultationText={''}
+          setConsultationText={setConsultationText}
+        />
+        ,
+      </ConsultationContext.Provider>,
     )
 
     const mockOnRecording = (SocketConnection as jest.Mock).mock.calls[0][2]
@@ -117,13 +159,26 @@ describe('Consultation Pad Contents', () => {
     ;(SocketConnection as jest.Mock).mockImplementation(
       () => mockSocketConnection,
     )
+    const mockPatientDetails: PatientDetails = {
+      patientUuid: 'abc',
+      locationUuid: 'def',
+      isActiveVisit: true,
+    }
+
+    const value = {
+      patientDetails: mockPatientDetails,
+      savedConsultationNotes: '',
+      setSavedConsultationNotes: jest.fn(),
+    }
     render(
-      <ConsultationPadContents
-        closeConsultationPad={handleClose}
-        consultationText={''}
-        setConsultationText={setConsultationText}
-        setSavedNotes={setSavedNotes}
-      />,
+      <ConsultationContext.Provider value={value}>
+        <ConsultationPadContents
+          closeConsultationPad={handleClose}
+          consultationText={''}
+          setConsultationText={setConsultationText}
+        />
+        ,
+      </ConsultationContext.Provider>,
     )
 
     const mockOnIncomingMessage = (SocketConnection as jest.Mock).mock
@@ -162,14 +217,26 @@ describe('Consultation Pad Contents', () => {
     ;(SocketConnection as jest.Mock).mockImplementation(
       () => mockSocketConnection,
     )
+    const mockPatientDetails: PatientDetails = {
+      patientUuid: 'abc',
+      locationUuid: 'def',
+      isActiveVisit: true,
+    }
 
+    const value = {
+      patientDetails: mockPatientDetails,
+      savedConsultationNotes: '',
+      setSavedConsultationNotes: jest.fn(),
+    }
     render(
-      <ConsultationPadContents
-        closeConsultationPad={handleClose}
-        consultationText={'Consultation'}
-        setConsultationText={setConsultationText}
-        setSavedNotes={setSavedNotes}
-      />,
+      <ConsultationContext.Provider value={value}>
+        <ConsultationPadContents
+          closeConsultationPad={handleClose}
+          consultationText={'Consultation'}
+          setConsultationText={setConsultationText}
+        />
+        , ,
+      </ConsultationContext.Provider>,
     )
 
     const mockOnIncomingMessage = (SocketConnection as jest.Mock).mock
@@ -208,15 +275,27 @@ describe('Consultation Pad Contents', () => {
     ;(SocketConnection as jest.Mock).mockImplementation(
       () => mockSocketConnection,
     )
-    render(
-      <ConsultationPadContents
-        closeConsultationPad={handleClose}
-        consultationText={'Consultation'}
-        setConsultationText={setConsultationText}
-        setSavedNotes={setSavedNotes}
-      />,
-    )
+    const mockPatientDetails: PatientDetails = {
+      patientUuid: 'abc',
+      locationUuid: 'def',
+      isActiveVisit: true,
+    }
 
+    const value = {
+      patientDetails: mockPatientDetails,
+      savedConsultationNotes: '',
+      setSavedConsultationNotes: jest.fn(),
+    }
+    render(
+      <ConsultationContext.Provider value={value}>
+        <ConsultationPadContents
+          closeConsultationPad={handleClose}
+          consultationText={'Consultation'}
+          setConsultationText={setConsultationText}
+        />
+        , ,
+      </ConsultationContext.Provider>,
+    )
     expect(
       screen.getByRole('button', {
         name: /Save/i,
@@ -244,14 +323,18 @@ describe('Consultation Pad Contents', () => {
       locationUuid: 'baf7bd38-d225-11e4-9c67-080027b662ec',
       isActiveVisit: true,
     }
+    const value = {
+      patientDetails: patientDetails,
+      savedConsultationNotes: '',
+      setSavedConsultationNotes: jest.fn(),
+    }
 
     render(
-      <ConsultationContext.Provider value={patientDetails}>
+      <ConsultationContext.Provider value={value}>
         <ConsultationPadContents
           closeConsultationPad={handleClose}
           consultationText={'Consultation Notes'}
           setConsultationText={setConsultationText}
-          setSavedNotes={setSavedNotes}
         />
       </ConsultationContext.Provider>,
     )
@@ -294,13 +377,17 @@ describe('Consultation Pad Contents', () => {
       isActiveVisit: true,
     }
 
+    const value = {
+      patientDetails: patientDetails,
+      savedConsultationNotes: '',
+      setSavedConsultationNotes: jest.fn(),
+    }
     render(
-      <ConsultationContext.Provider value={patientDetails}>
+      <ConsultationContext.Provider value={value}>
         <ConsultationPadContents
           closeConsultationPad={handleClose}
           consultationText={'Consultation Notes'}
           setConsultationText={setConsultationText}
-          setSavedNotes={setSavedNotes}
         />
       </ConsultationContext.Provider>,
     )
@@ -322,13 +409,13 @@ describe('Consultation Pad Contents', () => {
     )
   })
 
-  it('should save consultation notes when clicked on save button and active consultation encounter is present', async () => {
+  it('should save consultation notes and create new obs on click of save button when active consultation encounter is present and consultation obs is not present', async () => {
     global.fetch = jest.fn().mockImplementation()
 
     const mockFetch = global.fetch as jest.Mock
     mockFetch
       .mockResolvedValueOnce({
-        json: () => mockVisitResponseWithActiveEncounter,
+        json: () => mockVisitResponseWithActiveEncounterWithoutConsultationObs,
         ok: true,
       })
       .mockResolvedValueOnce({
@@ -340,20 +427,26 @@ describe('Consultation Pad Contents', () => {
         ok: true,
       })
 
+    const setSavedConsultationNotes = jest.fn()
     const patientDetails: PatientDetails = {
       patientUuid: 'dc9444c6-ad55-4200-b6e9-407e025eb948',
       locationUuid: 'baf7bd38-d225-11e4-9c67-080027b662ec',
       isActiveVisit: true,
     }
+
+    const value = {
+      patientDetails: patientDetails,
+      savedConsultationNotes: '',
+      setSavedConsultationNotes: setSavedConsultationNotes,
+    }
     const consultationText = 'Consultation Notes'
 
     render(
-      <ConsultationContext.Provider value={patientDetails}>
+      <ConsultationContext.Provider value={value}>
         <ConsultationPadContents
           closeConsultationPad={handleClose}
           consultationText={consultationText}
           setConsultationText={setConsultationText}
-          setSavedNotes={setSavedNotes}
         />
       </ConsultationContext.Provider>,
     )
@@ -381,7 +474,72 @@ describe('Consultation Pad Contents', () => {
     expect(conceptUrl).toBe('/openmrs/ws/rest/v1/concept?q="Consultation Note')
     expect(obsUrl).toBe('/openmrs/ws/rest/v1/obs')
     expect(obsJsonBody.value).toBe('Consultation Notes')
-    expect(setSavedNotes).toHaveBeenCalledWith(consultationText)
+    expect(setSavedConsultationNotes).toHaveBeenCalledWith(consultationText)
+  })
+
+  it('should save consultation notes and update the obs on click of save button when active consultation encounter and consultation obs is already present', async () => {
+    global.fetch = jest.fn().mockImplementation()
+
+    const mockFetch = global.fetch as jest.Mock
+    mockFetch
+      .mockResolvedValueOnce({
+        json: () => mockVisitResponseWithActiveEncounter,
+        ok: true,
+      })
+      .mockResolvedValue({
+        json: () => updateObsResponse,
+        ok: true,
+      })
+
+    const setSavedConsultationNotes = jest.fn()
+    const patientDetails: PatientDetails = {
+      patientUuid: 'dc9444c6-ad55-4200-b6e9-407e025eb948',
+      locationUuid: 'baf7bd38-d225-11e4-9c67-080027b662ec',
+      isActiveVisit: true,
+    }
+
+    const value = {
+      patientDetails: patientDetails,
+      savedConsultationNotes: '',
+      setSavedConsultationNotes: setSavedConsultationNotes,
+    }
+    const consultationText = 'Consultation Notes'
+
+    render(
+      <ConsultationContext.Provider value={value}>
+        <ConsultationPadContents
+          closeConsultationPad={handleClose}
+          consultationText={consultationText}
+          setConsultationText={setConsultationText}
+        />
+      </ConsultationContext.Provider>,
+    )
+
+    expect(
+      screen.getByRole('button', {
+        name: /Save/i,
+      }),
+    ).toBeEnabled()
+
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /Save/i,
+      }),
+    )
+
+    const visiturl = mockFetch.mock.calls[0][0]
+    const updateObsUrl = mockFetch.mock.calls[1][0]
+    const obsJsonBody = JSON.parse(mockFetch.mock.calls[1][1].body)
+
+    expect(fetch).toBeCalledTimes(2)
+    expect(visiturl).toBe(
+      customVisitUrl(patientDetails.patientUuid, patientDetails.locationUuid),
+    )
+    expect(updateObsUrl).toBe(
+      '/openmrs/ws/rest/v1/obs/8dd4d632-ec99-4056-b6dc-d489f1dc5f30',
+    )
+    expect(obsJsonBody.value).toBe('Consultation Notes')
+    expect(setSavedConsultationNotes).toHaveBeenCalledWith(consultationText)
   })
 
   it('should update the consultation notes when user is typing manually on consultation pad', () => {
@@ -396,13 +554,26 @@ describe('Consultation Pad Contents', () => {
     const setConsultationText = jest.fn()
     setConsultationText.mockImplementation(value => (consultationText = value))
 
+    const patientDetails: PatientDetails = {
+      patientUuid: 'dc9444c6-ad55-4200-b6e9-407e025eb948',
+      locationUuid: 'baf7bd38-d225-11e4-9c67-080027b662ec',
+      isActiveVisit: true,
+    }
+
+    const value = {
+      patientDetails: patientDetails,
+      savedConsultationNotes: '',
+      setSavedConsultationNotes: jest.fn(),
+    }
     render(
-      <ConsultationPadContents
-        closeConsultationPad={handleClose}
-        consultationText={consultationText}
-        setConsultationText={setConsultationText}
-        setSavedNotes={setSavedNotes}
-      />,
+      <ConsultationContext.Provider value={value}>
+        <ConsultationPadContents
+          closeConsultationPad={handleClose}
+          consultationText={consultationText}
+          setConsultationText={setConsultationText}
+        />
+        ,
+      </ConsultationContext.Provider>,
     )
 
     expect(

--- a/src/components/consultation-pad-contents/consultation-pad-contents.tsx
+++ b/src/components/consultation-pad-contents/consultation-pad-contents.tsx
@@ -1,19 +1,14 @@
 import {Button, TextArea} from '@carbon/react'
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'react'
+import React, {useCallback, useEffect, useRef, useState} from 'react'
 import {MicrophoneFilled, StopFilled} from '@carbon/icons-react'
 import styles from './consultation-pad-contents.scss'
 import SocketConnection from '../../utils/socket-connection/socket-connection'
 import {streamingURL} from '../../utils/constants'
 import {saveConsultationNotes} from './consultation-pad-contents.resources'
 import {
-  ConsultationContext,
   PatientDetails,
+  usePatientDetails,
+  useSavedConsultationNotes,
 } from '../../context/consultation-context'
 import {
   addSaveButtonListener,
@@ -24,12 +19,12 @@ export function ConsultationPadContents({
   closeConsultationPad,
   consultationText,
   setConsultationText,
-  setSavedNotes,
 }) {
   const [isRecording, setIsRecording] = useState(false)
   const [recordedText, setRecordedText] = useState('')
 
-  const patientDetails: PatientDetails = useContext(ConsultationContext)
+  const patientDetails: PatientDetails = usePatientDetails()
+  const {setSavedConsultationNotes} = useSavedConsultationNotes()
 
   const consultationTextRef = useRef(null)
   const recordedTextRef = useRef(null)
@@ -151,7 +146,7 @@ export function ConsultationPadContents({
 
   const clickSaveButton = useCallback(() => {
     saveConsultationNotes(consultationText, patientDetails)
-    setSavedNotes(consultationText)
+    setSavedConsultationNotes(consultationText)
     closeConsultationPad()
   }, [consultationText])
 

--- a/src/components/consultation-pad-contents/consultation-pad-contents.tsx
+++ b/src/components/consultation-pad-contents/consultation-pad-contents.tsx
@@ -58,7 +58,11 @@ export function ConsultationPadContents({
       onIncomingMessage,
       onRecording,
     )
-    addSaveButtonListener(patientDetails, closeConsultationPad, setSavedNotes)
+    addSaveButtonListener(
+      patientDetails,
+      closeConsultationPad,
+      setSavedConsultationNotes,
+    )
     return () => {
       if (isRecordingRef.current) {
         if (recordedTextRef.current != '') {

--- a/src/components/consultation-pad/consultation-pad.test.tsx
+++ b/src/components/consultation-pad/consultation-pad.test.tsx
@@ -53,13 +53,26 @@ describe('Consultation Pad', () => {
       () => mockSocketConnection,
     )
 
+    const mockPatientDetails: PatientDetails = {
+      patientUuid: 'abc',
+      locationUuid: 'def',
+      isActiveVisit: true,
+    }
+
+    const value = {
+      patientDetails: mockPatientDetails,
+      savedConsultationNotes: '',
+      setSavedConsultationNotes: jest.fn(),
+    }
     const {unmount} = render(
-      <ConsultationPad
-        setShowConsultationPad={jest.fn()}
-        consultationText={consultationText}
-        setConsultationText={setConsultationText}
-        setSavedNotes={jest.fn()}
-      />,
+      <ConsultationContext.Provider value={value}>
+        <ConsultationPad
+          setShowConsultationPad={jest.fn()}
+          consultationText={consultationText}
+          setConsultationText={setConsultationText}
+        />
+        ,
+      </ConsultationContext.Provider>,
     )
 
     const mockOnIncomingMessage = (SocketConnection as jest.Mock).mock
@@ -99,13 +112,26 @@ describe('Consultation Pad', () => {
     ;(SocketConnection as jest.Mock).mockImplementation(
       () => mockSocketConnection,
     )
+    const mockPatientDetails: PatientDetails = {
+      patientUuid: 'abc',
+      locationUuid: 'def',
+      isActiveVisit: true,
+    }
+
+    const value = {
+      patientDetails: mockPatientDetails,
+      savedConsultationNotes: '',
+      setSavedConsultationNotes: jest.fn(),
+    }
     const {unmount} = render(
-      <ConsultationPad
-        setShowConsultationPad={jest.fn()}
-        consultationText={consultationText}
-        setConsultationText={setConsultationText}
-        setSavedNotes={jest.fn()}
-      />,
+      <ConsultationContext.Provider value={value}>
+        <ConsultationPad
+          setShowConsultationPad={jest.fn()}
+          consultationText={consultationText}
+          setConsultationText={setConsultationText}
+        />
+        ,
+      </ConsultationContext.Provider>,
     )
 
     const mockOnIncomingMessage = (SocketConnection as jest.Mock).mock

--- a/src/components/consultation-pad/consultation-pad.test.tsx
+++ b/src/components/consultation-pad/consultation-pad.test.tsx
@@ -2,6 +2,10 @@ import {render, screen, waitFor} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 import SocketConnection from '../../utils/socket-connection/socket-connection'
+import {
+  ConsultationContext,
+  PatientDetails,
+} from '../../context/consultation-context'
 import {ConsultationPad} from './consultation-pad'
 
 jest.mock('../../utils/socket-connection/socket-connection')
@@ -9,13 +13,26 @@ jest.mock('../../utils/socket-connection/socket-connection')
 describe('Consultation Pad', () => {
   afterEach(() => jest.clearAllMocks())
   it('should show consultation notes heading, minimize icon, start mic and save button when consultation pad component is rendered', () => {
+    const mockPatientDetails: PatientDetails = {
+      patientUuid: 'abc',
+      locationUuid: 'def',
+      isActiveVisit: true,
+    }
+
+    const value = {
+      patientDetails: mockPatientDetails,
+      savedConsultationNotes: '',
+      setSavedConsultationNotes: jest.fn(),
+    }
     render(
-      <ConsultationPad
-        setShowConsultationPad={jest.fn()}
-        consultationText={''}
-        setConsultationText={jest.fn()}
-        setSavedNotes={jest.fn()}
-      />,
+      <ConsultationContext.Provider value={value}>
+        <ConsultationPad
+          setShowConsultationPad={jest.fn()}
+          consultationText={''}
+          setConsultationText={jest.fn()}
+        />
+        ,
+      </ConsultationContext.Provider>,
     )
 
     expect(screen.getByRole('heading', {name: /Consultation Notes/i}))

--- a/src/components/consultation-pad/consultation-pad.tsx
+++ b/src/components/consultation-pad/consultation-pad.tsx
@@ -6,7 +6,6 @@ export function ConsultationPad({
   consultationText,
   setConsultationText,
   setShowConsultationPad,
-  setSavedNotes,
 }) {
   const clickMinimizeIcon = useCallback(() => setShowConsultationPad(false), [])
 
@@ -19,7 +18,6 @@ export function ConsultationPad({
         closeConsultationPad={clickMinimizeIcon}
         consultationText={consultationText}
         setConsultationText={setConsultationText}
-        setSavedNotes={setSavedNotes}
       />
     </DraggableBox>
   )

--- a/src/context/consultation-context.tsx
+++ b/src/context/consultation-context.tsx
@@ -19,7 +19,7 @@ export interface PatientDetails {
 export interface ConsultationContextProps {
   patientDetails: PatientDetails
   savedConsultationNotes: string
-  setSavedConsultationNotes: Function
+  setSavedConsultationNotes: React.Dispatch<React.SetStateAction<string>>
 }
 
 export const ConsultationContext =

--- a/src/context/consultation-context.tsx
+++ b/src/context/consultation-context.tsx
@@ -1,6 +1,10 @@
 import React, {useEffect, useState} from 'react'
 import {getApiCall} from '../utils/api-utils'
-import {defaultVisitUrl} from '../utils/constants'
+import {customVisitUrl} from '../utils/constants'
+import {
+  getActiveConsultationEncounter,
+  getConsultationObs,
+} from '../utils/encounter-details/encounter-details'
 import {
   getLocationUuid,
   getPatientUuid,
@@ -11,30 +15,77 @@ export interface PatientDetails {
   locationUuid: string
   isActiveVisit: boolean
 }
-async function fetchActiveVisits(patiendId, locationId) {
-  const activeVisitResponse = await getApiCall(
-    defaultVisitUrl(patiendId, locationId),
-  )
-  return activeVisitResponse?.results?.length > 0 ? true : false
+
+export interface ConsultationContextProps {
+  patientDetails: PatientDetails
+  savedConsultationNotes: string
+  setSavedConsultationNotes: Function
 }
 
-export const ConsultationContext = React.createContext({} as PatientDetails)
+export const ConsultationContext =
+  React.createContext<ConsultationContextProps>(null)
+
+async function fetchActiveVisitResponse(patiendId, locationId) {
+  const activeVisitResponse = await getApiCall(
+    customVisitUrl(patiendId, locationId),
+  )
+  return activeVisitResponse
+}
+
+export function usePatientDetails() {
+  const context = React.useContext(ConsultationContext)
+  return context.patientDetails
+}
+
+export function useSavedConsultationNotes() {
+  const context = React.useContext(ConsultationContext)
+  return {
+    savedConsultationNotes: context.savedConsultationNotes,
+    setSavedConsultationNotes: context.setSavedConsultationNotes,
+  }
+}
 
 function ConsultationContextProvider({children}) {
   const [patientDetails, setPatientDetails] = useState<PatientDetails>()
   const [patientUuid, setPatientUuid] = useState('')
   const [locationUuid, setLocationUuid] = useState('')
+  const [savedConsultationNotes, setSavedConsultationNotes] = useState('')
+
+  const updateSavedConsultationNotes = activeVisitResponse => {
+    const consultationActiveEncounter =
+      getActiveConsultationEncounter(activeVisitResponse)
+
+    if (consultationActiveEncounter) {
+      const consultationObs = getConsultationObs(consultationActiveEncounter)
+      if (consultationObs) {
+        const savedData = consultationObs.display.match(
+          /^Consultation Note: (.*)/,
+        )[1]
+        setSavedConsultationNotes(savedData)
+      }
+    }
+  }
+
+  const updatePatientDetails = async (patientUuid, locationUuid) => {
+    const activeVisitResponse = await fetchActiveVisitResponse(
+      patientUuid,
+      locationUuid,
+    )
+    const isActiveVisit = activeVisitResponse?.results?.length > 0
+
+    if (isActiveVisit) {
+      setPatientDetails({
+        patientUuid: patientUuid,
+        locationUuid: locationUuid,
+        isActiveVisit: isActiveVisit,
+      })
+      updateSavedConsultationNotes(activeVisitResponse)
+    }
+  }
 
   useEffect(() => {
     if (patientUuid && locationUuid) {
-      const activeVisit = fetchActiveVisits(patientUuid, locationUuid)
-      activeVisit.then(response => {
-        setPatientDetails({
-          patientUuid: patientUuid,
-          locationUuid: locationUuid,
-          isActiveVisit: response,
-        })
-      })
+      updatePatientDetails(patientUuid, locationUuid)
     } else {
       setPatientDetails({
         patientUuid: patientUuid,
@@ -54,8 +105,14 @@ function ConsultationContextProvider({children}) {
     window.addEventListener('hashchange', onUrlChangeCallback)
   }, [])
 
+  const value = {
+    patientDetails,
+    savedConsultationNotes,
+    setSavedConsultationNotes,
+  }
+
   return (
-    <ConsultationContext.Provider value={patientDetails}>
+    <ConsultationContext.Provider value={value}>
       {children}
     </ConsultationContext.Provider>
   )

--- a/src/context/consultation-context.tsx
+++ b/src/context/consultation-context.tsx
@@ -92,6 +92,7 @@ function ConsultationContextProvider({children}) {
         locationUuid: locationUuid,
         isActiveVisit: false,
       })
+      setSavedConsultationNotes('')
     }
   }, [patientUuid, locationUuid])
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -5,5 +5,6 @@ export const saveNotesUrl = '/openmrs/ws/rest/v1/obs'
 export const conceptUrl = '/openmrs/ws/rest/v1/concept?q="Consultation Note'
 export const customVisitUrl = (patientId, locationId) =>
   `/openmrs/ws/rest/v1/visit?includeInactive=false&patient=${patientId}&location=${locationId}&v=custom:(uuid,visitType,startDatetime,stopDatetime,encounters)`
-export const defaultVisitUrl = (patientId, locationId) =>
-  `/openmrs/ws/rest/v1/visit?includeInactive=false&patient=${patientId}&location=${locationId}`
+// export const defaultVisitUrl = (patientId, locationId) =>
+//   `/openmrs/ws/rest/v1/visit?includeInactive=false&patient=${patientId}&location=${locationId}`
+export const updateObsUrl = obsUuid => `/openmrs/ws/rest/v1/obs/${obsUuid}`

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -5,6 +5,4 @@ export const saveNotesUrl = '/openmrs/ws/rest/v1/obs'
 export const conceptUrl = '/openmrs/ws/rest/v1/concept?q="Consultation Note'
 export const customVisitUrl = (patientId, locationId) =>
   `/openmrs/ws/rest/v1/visit?includeInactive=false&patient=${patientId}&location=${locationId}&v=custom:(uuid,visitType,startDatetime,stopDatetime,encounters)`
-// export const defaultVisitUrl = (patientId, locationId) =>
-//   `/openmrs/ws/rest/v1/visit?includeInactive=false&patient=${patientId}&location=${locationId}`
 export const updateObsUrl = obsUuid => `/openmrs/ws/rest/v1/obs/${obsUuid}`

--- a/src/utils/encounter-details/encounter-details.ts
+++ b/src/utils/encounter-details/encounter-details.ts
@@ -35,7 +35,7 @@ export const getConsultationObs = consultationActiveEncounter => {
   let consultationObs = null
   if (observations) {
     consultationObs = observations.find(obs => {
-      return obs.display.match(/^Consultation Note:/) != null
+      return obs.display.match(/^Consultation Note:/) !== null
     })
   }
   return consultationObs

--- a/src/utils/encounter-details/encounter-details.ts
+++ b/src/utils/encounter-details/encounter-details.ts
@@ -1,0 +1,42 @@
+const MILLISECOND_TO_MINUTE_CONVERSION_FACTOR = 60000
+const SIXTY_MINUTES = 60
+
+export const isConsultationEncounterActive = consultationEncounter => {
+  const consultationEncounterDateTime = new Date(
+    consultationEncounter.encounterDatetime,
+  )
+  const currentDatetime = new Date()
+
+  const timeDifferenceInMinutes =
+    (currentDatetime.getTime() - consultationEncounterDateTime.getTime()) /
+    MILLISECOND_TO_MINUTE_CONVERSION_FACTOR
+
+  return timeDifferenceInMinutes < SIXTY_MINUTES
+}
+
+export const getEncounters = visitResponse => {
+  return visitResponse.results.length > 0
+    ? visitResponse.results[0].encounters
+    : null
+}
+
+export const getActiveConsultationEncounter = visitResponse => {
+  const encounters = getEncounters(visitResponse)
+  const consultationActiveEncounter = encounters?.find(
+    encounter =>
+      encounter.encounterType.display == 'Consultation' &&
+      isConsultationEncounterActive(encounter),
+  )
+  return consultationActiveEncounter
+}
+
+export const getConsultationObs = consultationActiveEncounter => {
+  const observations = consultationActiveEncounter.obs
+  let consultationObs = null
+  if (observations) {
+    consultationObs = observations.find(obs => {
+      return obs.display.match(/^Consultation Note:/) != null
+    })
+  }
+  return consultationObs
+}


### PR DESCRIPTION
## Requirements

- [X] This PR has a proper title that briefly describes the work done
- [X] I have squashed / amended the comments to make it more redable
- [X] I have included link to all the JIRA ticket('s)
- [X] I wrote the code as a pair or atleast performed a self-review of my own code
- [ ] I have updated the documentation on [Bahmni Wiki](https://bahmni.atlassian.net/wiki/spaces/BAH/overview) or [README](https://github.com/Bahmni/speech-assistant-frontend/blob/main/README.md) (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Summary
In case the doctor had saved notes for the patient during the ongoing encounter , then the notes should be reflected in the consultation box, so that the doctor can make changes to it and update. Right now, the notes once saved are not fetched in the consultation box and therefore the doctor is unable to make any changes to the notes, but can create a new entry.

## JIRA tickets
https://bahmni.atlassian.net/browse/BAH-2394