### PR TITLE
BAH-2153 | Creating encounter for saving consultation notes

### DIFF
--- a/src/__mocks__/activeVisitWithNoEncounter.mock.ts
+++ b/src/__mocks__/activeVisitWithNoEncounter.mock.ts
@@ -1,3 +1,155 @@
 export const mockVisitResponseWithNoEncounter = {
-  results: [],
+  results: [
+    {
+      uuid: '8281dd37-45c0-4a45-a939-ecb95fdb6ed7',
+      visitType: {
+        uuid: 'c22a5000-3f10-11e4-adec-0800271c1b75',
+        display: 'OPD',
+        name: 'OPD',
+        description: 'Visit for patients coming for OPD',
+        retired: false,
+        links: [
+          {
+            rel: 'self',
+            uri: 'http://localhost/openmrs/ws/rest/v1/visittype/c22a5000-3f10-11e4-adec-0800271c1b75',
+            resourceAlias: 'visittype',
+          },
+          {
+            rel: 'full',
+            uri: 'http://localhost/openmrs/ws/rest/v1/visittype/c22a5000-3f10-11e4-adec-0800271c1b75?v=full',
+            resourceAlias: 'visittype',
+          },
+        ],
+        resourceVersion: '1.9',
+      },
+      startDatetime: '2017-06-07T15:58:48.000+0000',
+      stopDatetime: null,
+      encounters: [
+        {
+          uuid: 'c86879a2-357b-4add-b109-231f4f076f79',
+          display: 'REG 06/07/2017',
+          encounterDatetime: '2017-06-07T15:59:03.000+0000',
+          patient: {
+            uuid: 'dc9444c6-ad55-4200-b6e9-407e025eb948',
+            display: 'GAN203010 - Test Radiology',
+            links: [
+              {
+                rel: 'self',
+                uri: 'http://localhost/openmrs/ws/rest/v1/patient/dc9444c6-ad55-4200-b6e9-407e025eb948',
+                resourceAlias: 'patient',
+              },
+            ],
+          },
+          location: {
+            uuid: 'baf7bd38-d225-11e4-9c67-080027b662ec',
+            display: 'General Ward',
+            links: [
+              {
+                rel: 'self',
+                uri: 'http://localhost/openmrs/ws/rest/v1/location/baf7bd38-d225-11e4-9c67-080027b662ec',
+                resourceAlias: 'location',
+              },
+            ],
+          },
+          form: null,
+          encounterType: {
+            uuid: '81888515-3f10-11e4-adec-0800271c1b75',
+            display: 'REG',
+            links: [
+              {
+                rel: 'self',
+                uri: 'http://localhost/openmrs/ws/rest/v1/encountertype/81888515-3f10-11e4-adec-0800271c1b75',
+                resourceAlias: 'encountertype',
+              },
+            ],
+          },
+          obs: [
+            {
+              uuid: '157ce9b8-52e0-415b-a62f-454bb99d230e',
+              display: 'Fee Information: 150.0',
+              links: [
+                {
+                  rel: 'self',
+                  uri: 'http://localhost/openmrs/ws/rest/v1/obs/157ce9b8-52e0-415b-a62f-454bb99d230e',
+                  resourceAlias: 'obs',
+                },
+              ],
+            },
+            {
+              uuid: '89dce1ab-5d08-4383-87e0-c2f0450ba3c0',
+              display: 'BMI Data: 831.76, true',
+              links: [
+                {
+                  rel: 'self',
+                  uri: 'http://localhost/openmrs/ws/rest/v1/obs/89dce1ab-5d08-4383-87e0-c2f0450ba3c0',
+                  resourceAlias: 'obs',
+                },
+              ],
+            },
+            {
+              uuid: 'b750cb59-36ca-495d-9646-fdf9fa5d8753',
+              display: 'Nutritional Values: ',
+              links: [
+                {
+                  rel: 'self',
+                  uri: 'http://localhost/openmrs/ws/rest/v1/obs/b750cb59-36ca-495d-9646-fdf9fa5d8753',
+                  resourceAlias: 'obs',
+                },
+              ],
+            },
+            {
+              uuid: '41816d59-2b0f-422f-826a-a77032494e0a',
+              display: 'BMI Status Data: Very Severely Obese, true',
+              links: [
+                {
+                  rel: 'self',
+                  uri: 'http://localhost/openmrs/ws/rest/v1/obs/41816d59-2b0f-422f-826a-a77032494e0a',
+                  resourceAlias: 'obs',
+                },
+              ],
+            },
+          ],
+          orders: [],
+          voided: false,
+          visit: {
+            uuid: '8281dd37-45c0-4a45-a939-ecb95fdb6ed7',
+            display: 'OPD @ General Ward - 06/07/2017 03:58 PM',
+            links: [
+              {
+                rel: 'self',
+                uri: 'http://localhost/openmrs/ws/rest/v1/visit/8281dd37-45c0-4a45-a939-ecb95fdb6ed7',
+                resourceAlias: 'visit',
+              },
+            ],
+          },
+          encounterProviders: [
+            {
+              uuid: '0c61a7e7-3532-4a65-b02a-a0e42e1781cf',
+              display: 'Super Man: Unknown',
+              links: [
+                {
+                  rel: 'self',
+                  uri: 'http://localhost/openmrs/ws/rest/v1/encounter/c86879a2-357b-4add-b109-231f4f076f79/encounterprovider/0c61a7e7-3532-4a65-b02a-a0e42e1781cf',
+                  resourceAlias: 'encounterprovider',
+                },
+              ],
+            },
+          ],
+          links: [
+            {
+              rel: 'self',
+              uri: 'http://localhost/openmrs/ws/rest/v1/encounter/c86879a2-357b-4add-b109-231f4f076f79',
+              resourceAlias: 'encounter',
+            },
+            {
+              rel: 'full',
+              uri: 'http://localhost/openmrs/ws/rest/v1/encounter/c86879a2-357b-4add-b109-231f4f076f79?v=full',
+              resourceAlias: 'encounter',
+            },
+          ],
+          resourceVersion: '1.9',
+        },
+      ],
+    },
+  ],
 }

--- a/src/__mocks__/encounterRoleResponse.mock.ts
+++ b/src/__mocks__/encounterRoleResponse.mock.ts
@@ -1,0 +1,15 @@
+export const mockConsultationEncounterRoleResopnse = {
+  results: [
+    {
+      uuid: 'a0b03050-c99b-11e0-9572-0800200c9a66',
+      display: 'Unknown',
+      links: [
+        {
+          rel: 'self',
+          uri: 'http://localhost/openmrs/ws/rest/v1/encounterrole/a0b03050-c99b-11e0-9572-0800200c9a66',
+          resourceAlias: 'encounterrole',
+        },
+      ],
+    },
+  ],
+}

--- a/src/__mocks__/encounterTypeResponse.mock.ts
+++ b/src/__mocks__/encounterTypeResponse.mock.ts
@@ -1,0 +1,15 @@
+export const mockConsultationEncounterTypeResponse = {
+  results: [
+    {
+      uuid: '81852aee-3f10-11e4-adec-0800271c1b75',
+      display: 'Consultation',
+      links: [
+        {
+          rel: 'self',
+          uri: 'http://localhost/openmrs/ws/rest/v1/encountertype/81852aee-3f10-11e4-adec-0800271c1b75',
+          resourceAlias: 'encountertype',
+        },
+      ],
+    },
+  ],
+}

--- a/src/__mocks__/sessionResponse.mock.ts
+++ b/src/__mocks__/sessionResponse.mock.ts
@@ -1,0 +1,60 @@
+export const mockSessionResponse = {
+  sessionId: '2A21896ADEFEF81893A989CE9FF875DF',
+  authenticated: true,
+  user: {
+    uuid: 'c1c21e11-3f10-11e4-adec-0800271c1b75',
+    display: 'superman',
+    username: 'superman',
+    systemId: 'superman',
+    userProperties: {
+      defaultLocale: 'en',
+      favouriteObsTemplates: '',
+      recentlyViewedPatients:
+        '[{"uuid":"bf379289-62b7-47b3-ab7b-5186cb6fc46c","name":"MARIAM MSAFIRI","identifier":"SEM203001"},{"uuid":"dc9444c6-ad55-4200-b6e9-407e025eb948","name":"Test Radiology","identifier":"GAN203010"},{"uuid":"3ae1ee52-e9b2-4934-876d-30711c0e3e2f","name":"Test Hypertension","identifier":"GAN203009"},{"uuid":"f5a00c0c-6230-4a13-b794-18ee0c137aa9","name":"Test TB","identifier":"GAN203008"},{"uuid":"0b573f9a-d75d-47fe-a655-043dc2f6b4fa","name":"Test Diabetes","identifier":"GAN203007"},{"uuid":"1dfff08c-141b-46df-b6a2-6b69080a5000","name":"Test Hyperthyroidism","identifier":"GAN203006"},{"uuid":"9a133946-e529-4d2d-a376-ce0045f0a685","name":"Sample Two","identifier":"GAN203005"},{"uuid":"4177d31e-b495-423d-b4ef-a454cc95c0d1","name":"SAmple one","identifier":"GAN203004"},{"uuid":"0c5a49d1-b5c2-4456-aacc-fe08d4a6ea09","name":"Test Hyperthyroidism","identifier":"GAN200031"},{"uuid":"7e8b881a-e2b9-4e61-9ae6-859c13212c58","name":"Test Patient","identifier":"GAN200062"}]',
+      loginAttempts: '0',
+      favouriteWards: 'General Ward###Labour Ward',
+    },
+    person: {
+      uuid: 'c1bc22a5-3f10-11e4-adec-0800271c1b75',
+      display: 'Super Man',
+    },
+    privileges: [
+      {
+        uuid: '697875ea-a662-11e6-91e9-0800270d80ce',
+        display: 'SuperAdmin',
+        name: 'SuperAdmin',
+      },
+      {
+        uuid: '8d94f280-c2cc-11de-8d13-0010c6dffd0f',
+        display: 'Provider',
+        name: 'Provider',
+      },
+    ],
+    links: [
+      {
+        rel: 'self',
+        uri: 'http://localhost/openmrs/ws/rest/v1/user/c1c21e11-3f10-11e4-adec-0800271c1b75',
+        resourceAlias: 'user',
+      },
+      {
+        rel: 'default',
+        uri: 'http://localhost/openmrs/ws/rest/v1/user/c1c21e11-3f10-11e4-adec-0800271c1b75?v=default',
+        resourceAlias: 'user',
+      },
+    ],
+  },
+  locale: 'en',
+  allowedLocales: ['en', 'es', 'fr', 'it', 'pt_BR'],
+  sessionLocation: null,
+  currentProvider: {
+    uuid: 'c1c26908-3f10-11e4-adec-0800271c1b75',
+    display: 'superman - Super Man',
+    links: [
+      {
+        rel: 'self',
+        uri: 'http://localhost/openmrs/ws/rest/v1/provider/c1c26908-3f10-11e4-adec-0800271c1b75',
+        resourceAlias: 'provider',
+      },
+    ],
+  },
+}

--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -1,11 +1,11 @@
 import {act, render, screen} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
+import {sessionUrl} from '../utils/constants'
 import {mockVisitResponseWithActiveEncounter} from '../__mocks__/activeVisitWithActiveEncounters.mock'
+import {mockSessionResponse} from '../__mocks__/sessionResponse.mock'
 import {mockVisitResponse} from '../__mocks__/visitResponse.mock'
 import App from './App'
-
-global.fetch = jest.fn().mockImplementation()
 
 describe('Speech Assistant App', () => {
   const testUrlWithPatientId =
@@ -13,7 +13,8 @@ describe('Speech Assistant App', () => {
   const testSearchUrl = 'http://localhost/patient/search'
   const testCookieWithLocationId =
     'bahmni.user=%22superman%22; app.clinical.grantProviderAccessData=null; bahmni.user.location=%7B%22name%22%3A%22OPD-1%22%2C%22uuid%22%3A%22c58e12ed-3f12-11e4-adec-0800271c1b75%22%7D'
-  const mockFetch = global.fetch as jest.Mock
+
+  afterEach(() => jest.clearAllMocks())
 
   it('should not show consultation pad button when patient uuid is not present in the url', () => {
     Object.defineProperty(window, 'location', {
@@ -22,6 +23,12 @@ describe('Speech Assistant App', () => {
       },
     })
 
+    global.fetch = jest.fn().mockImplementation()
+    const mockFetch = global.fetch as jest.Mock
+    mockFetch.mockResolvedValue({
+      json: () => mockSessionResponse,
+      ok: true,
+    })
     render(<App />)
 
     expect(
@@ -37,7 +44,15 @@ describe('Speech Assistant App', () => {
         href: testUrlWithPatientId,
       },
     })
+    global.fetch = jest.fn().mockImplementation()
+    const mockFetch = global.fetch as jest.Mock
+    mockFetch.mockResolvedValue({
+      json: () => mockSessionResponse,
+      ok: true,
+    })
+
     render(<App />)
+
     expect(
       screen.queryByRole('button', {
         name: /Notes/i,
@@ -53,11 +68,20 @@ describe('Speech Assistant App', () => {
     })
     Object.defineProperty(document, 'cookie', {value: testCookieWithLocationId})
 
+    global.fetch = jest.fn().mockImplementation()
+    const mockFetch = global.fetch as jest.Mock
+    mockFetch
+      .mockResolvedValueOnce({
+        json: () => mockSessionResponse,
+        ok: true,
+      })
+      .mockResolvedValue({
+        json: () => mockVisitResponse,
+        ok: true,
+      })
+
     render(<App />)
-    mockFetch.mockResolvedValue({
-      json: () => mockVisitResponse,
-      ok: true,
-    })
+
     act(() => {
       window.location.href = testUrlWithPatientId
       window.dispatchEvent(new HashChangeEvent('hashchange'))
@@ -67,8 +91,10 @@ describe('Speech Assistant App', () => {
       name: /Notes/i,
     })
     expect(consultationPadButton).toBeInTheDocument()
-    const visitUrl = mockFetch.mock.calls[0][0]
-    expect(visitUrl).toBe(
+    const mockSessionUrl = mockFetch.mock.calls[0][0]
+    const mockVisitUrl = mockFetch.mock.calls[1][0]
+    expect(mockSessionUrl).toBe(sessionUrl)
+    expect(mockVisitUrl).toBe(
       '/openmrs/ws/rest/v1/visit?includeInactive=false&patient=dbebab89-40b4-4121-a786-110e61bbc714&location=c58e12ed-3f12-11e4-adec-0800271c1b75&v=custom:(uuid,visitType,startDatetime,stopDatetime,encounters)',
     )
   })
@@ -80,6 +106,7 @@ describe('Speech Assistant App', () => {
       },
     })
     Object.defineProperty(document, 'cookie', {value: testCookieWithLocationId})
+    const mockFetch = global.fetch as jest.Mock
     mockFetch.mockResolvedValue({
       json: () => mockVisitResponseWithActiveEncounter,
       ok: true,
@@ -107,11 +134,19 @@ describe('Speech Assistant App', () => {
       },
     })
     Object.defineProperty(document, 'cookie', {value: testCookieWithLocationId})
-    const mockEmptyResponse = {}
-    mockFetch.mockResolvedValue({
-      json: () => mockEmptyResponse,
-      ok: true,
-    })
+
+    const mockEmptyResponse = {results: []}
+    global.fetch = jest.fn().mockImplementation()
+    const mockFetch = global.fetch as jest.Mock
+    mockFetch
+      .mockResolvedValueOnce({
+        json: () => mockSessionResponse,
+        ok: true,
+      })
+      .mockResolvedValue({
+        json: () => mockEmptyResponse,
+        ok: true,
+      })
 
     render(<App />)
 
@@ -125,8 +160,11 @@ describe('Speech Assistant App', () => {
         name: /Notes/i,
       }),
     ).not.toBeInTheDocument()
-    const visitUrl = mockFetch.mock.calls[0][0]
-    expect(visitUrl).toBe(
+
+    const mockSessionUrl = mockFetch.mock.calls[0][0]
+    const mockVisitUrl = mockFetch.mock.calls[1][0]
+    expect(mockSessionUrl).toBe(sessionUrl)
+    expect(mockVisitUrl).toBe(
       '/openmrs/ws/rest/v1/visit?includeInactive=false&patient=dbebab89-40b4-4121-a786-110e61bbc714&location=c58e12ed-3f12-11e4-adec-0800271c1b75&v=custom:(uuid,visitType,startDatetime,stopDatetime,encounters)',
     )
   })

--- a/src/components/active-consultation/active-consultation.test.tsx
+++ b/src/components/active-consultation/active-consultation.test.tsx
@@ -12,6 +12,7 @@ describe('Active Consultation', () => {
       patientUuid: 'abc',
       locationUuid: 'def',
       isActiveVisit: false,
+      providerUuid: '',
     }
 
     const value = {
@@ -38,6 +39,7 @@ describe('Active Consultation', () => {
       patientUuid: 'abc',
       locationUuid: 'def',
       isActiveVisit: true,
+      providerUuid: '',
     }
 
     const value = {

--- a/src/components/bahmni/bahmni-save-button-listener/save-button-listener.test.ts
+++ b/src/components/bahmni/bahmni-save-button-listener/save-button-listener.test.ts
@@ -19,6 +19,7 @@ describe('Bahmni save button listener', () => {
       patientUuid: 'dc9444c6-ad55-4200-b6e9-407e025eb948',
       locationUuid: 'baf7bd38-d225-11e4-9c67-080027b662ec',
       isActiveVisit: true,
+      providerUuid: '',
     }
 
     setConsultationNotes('testing')

--- a/src/components/consultation-pad-contents/consultation-pad-contents.resources.ts
+++ b/src/components/consultation-pad-contents/consultation-pad-contents.resources.ts
@@ -134,7 +134,7 @@ async function createEncounterWithObs(
   const encounterRoleUuid = await getEncounterRoleUuid()
   const consultationNotesConceptUuid = await getconsultationNotesConceptUuid()
 
-  const requestbody = encounterRequestBody(
+  const encounterData = encounterRequestBody(
     encounterDatetime,
     visitUuid,
     encounterTypeUuid,
@@ -143,7 +143,7 @@ async function createEncounterWithObs(
     consultationText,
     patientDetails,
   )
-  postApiCall(encounterUrl, requestbody).then(response => response.json())
+  postApiCall(encounterUrl, encounterData).then(response => response.json())
 }
 
 export const updateConsultationObs = (obsUuid, consultationText) => {
@@ -179,9 +179,8 @@ export const saveConsultationNotes = async (
   const visitResponse = await getApiCall(
     visitUrl(patientDetails.patientUuid, patientDetails.locationUuid),
   )
-  const consultationActiveEncounter = await getActiveConsultationEncounter(
-    visitResponse,
-  )
+  const consultationActiveEncounter =
+    getActiveConsultationEncounter(visitResponse)
   const visitUuid = visitResponse?.results[0]?.uuid
   const encounterDatetime = new Date().toISOString()
 

--- a/src/components/consultation-pad-contents/consultation-pad-contents.resources.ts
+++ b/src/components/consultation-pad-contents/consultation-pad-contents.resources.ts
@@ -1,14 +1,17 @@
 import {postApiCall, getApiCall} from '../../utils/api-utils'
 import {
-  saveNotesUrl,
-  conceptUrl,
-  customVisitUrl,
-  updateObsUrl,
-} from '../../utils/constants'
-import {
   getActiveConsultationEncounter,
   getConsultationObs,
 } from '../../utils/encounter-details/encounter-details'
+import {
+  visitUrl,
+  consultationEncounterTypeUrl,
+  encounterUrl,
+  unknownEncounterRoleUrl,
+  consultationNotesConceptUrl,
+  saveNotesUrl,
+  updateObsUrl,
+} from '../../utils/constants'
 
 interface ObsType {
   person: string
@@ -17,6 +20,26 @@ interface ObsType {
   value: string
   location: string
   encounter: string
+}
+
+interface EncounterProvidersType {
+  provider: string
+  encounterRole: string
+}
+
+interface EncounterObsType {
+  concept: string
+  value: string
+}
+
+interface EncounterType {
+  encounterDatetime: string
+  patient: string
+  encounterType: string
+  location: string
+  encounterProviders: EncounterProvidersType[]
+  obs: EncounterObsType[]
+  visit: string
 }
 
 const requestbody = (
@@ -28,41 +51,125 @@ const requestbody = (
   encounter,
 ): ObsType => {
   return {
-    person: person,
-    concept: concept,
-    obsDatetime: obsDatetime,
-    value: value,
-    location: location,
-    encounter: encounter,
+    person,
+    concept,
+    obsDatetime,
+    value,
+    location,
+    encounter,
   }
 }
 
-export const saveObsData = async (
+const encounterRequestBody = (
+  encounterDatetime,
+  visitUuid,
+  encounterTypeUuid,
+  encounterRoleUuid,
+  conceptuuid,
+  value,
+  patientDetails,
+): EncounterType => {
+  return {
+    encounterDatetime,
+    patient: patientDetails.patientUuid,
+    encounterType: encounterTypeUuid,
+    location: patientDetails.locationUuid,
+    encounterProviders: [
+      {
+        provider: patientDetails.providerUuid,
+        encounterRole: encounterRoleUuid,
+      },
+    ],
+    obs: [
+      {
+        concept: conceptuuid,
+        value,
+      },
+    ],
+    visit: visitUuid,
+  }
+}
+
+const getEncounterTypeUuid = async () => {
+  const response = await getApiCall(consultationEncounterTypeUrl)
+  return response?.results[0]?.uuid
+}
+const getEncounterRoleUuid = async () => {
+  const response = await getApiCall(unknownEncounterRoleUrl)
+  return response?.results[0]?.uuid
+}
+
+const getconsultationNotesConceptUuid = async () => {
+  const response = await getApiCall(consultationNotesConceptUrl)
+  return response?.results[0]?.uuid
+}
+
+export const createConsultationObs = async (
+  encounterDatetime,
   consultationText,
   patientUuid,
   location,
   encounterUuid,
 ) => {
-  const conceptResponse = await getApiCall(conceptUrl)
-  const conceptUuid = conceptResponse.results[0].uuid
-
-  const obsDatetime = new Date().toISOString()
-
+  const consultationNotesConceptUuid = await getconsultationNotesConceptUuid()
   const body = requestbody(
     patientUuid,
-    conceptUuid,
-    obsDatetime,
+    consultationNotesConceptUuid,
+    encounterDatetime,
     consultationText,
     location,
     encounterUuid,
   )
 
-  postApiCall(saveNotesUrl, body).then(response => response.json())
+  await postApiCall(saveNotesUrl, body).then(response => response.json())
 }
 
-export const updateObsData = (obsUuid, consultationText) => {
+async function createEncounterWithObs(
+  encounterDatetime,
+  visitUuid,
+  consultationText,
+  patientDetails,
+) {
+  const encounterTypeUuid = await getEncounterTypeUuid()
+  const encounterRoleUuid = await getEncounterRoleUuid()
+  const consultationNotesConceptUuid = await getconsultationNotesConceptUuid()
+
+  const requestbody = encounterRequestBody(
+    encounterDatetime,
+    visitUuid,
+    encounterTypeUuid,
+    encounterRoleUuid,
+    consultationNotesConceptUuid,
+    consultationText,
+    patientDetails,
+  )
+  postApiCall(encounterUrl, requestbody).then(response => response.json())
+}
+
+export const updateConsultationObs = (obsUuid, consultationText) => {
   const body = {value: consultationText}
   postApiCall(updateObsUrl(obsUuid), body).then(response => response.json())
+}
+
+const saveConsultationObs = (
+  consultationActiveEncounter,
+  consultationText,
+  encounterDatetime,
+  patientDetails,
+) => {
+  const consultationObs = getConsultationObs(consultationActiveEncounter)
+  if (consultationObs) {
+    const obsUuid = consultationObs.uuid
+    updateConsultationObs(obsUuid, consultationText)
+  } else {
+    createConsultationObs(
+      encounterDatetime,
+      consultationText,
+      patientDetails.patientUuid,
+      patientDetails.location,
+      consultationActiveEncounter.uuid,
+    )
+  }
 }
 
 export const saveConsultationNotes = async (
@@ -70,25 +177,26 @@ export const saveConsultationNotes = async (
   patientDetails,
 ) => {
   const visitResponse = await getApiCall(
-    customVisitUrl(patientDetails.patientUuid, patientDetails.locationUuid),
+    visitUrl(patientDetails.patientUuid, patientDetails.locationUuid),
   )
-
   const consultationActiveEncounter = await getActiveConsultationEncounter(
     visitResponse,
   )
+  const visitUuid = visitResponse?.results[0]?.uuid
+  const encounterDatetime = new Date().toISOString()
 
   if (consultationActiveEncounter) {
-    const consultationObs = getConsultationObs(consultationActiveEncounter)
-    if (consultationObs) {
-      const obsUuid = consultationObs.uuid
-      updateObsData(obsUuid, consultationText)
-    } else {
-      saveObsData(
-        consultationText,
-        patientDetails.patientUuid,
-        patientDetails.location,
-        consultationActiveEncounter.uuid,
-      )
-    }
-  }
+    saveConsultationObs(
+      consultationActiveEncounter,
+      consultationText,
+      encounterDatetime,
+      patientDetails,
+    )
+  } else
+    createEncounterWithObs(
+      encounterDatetime,
+      visitUuid,
+      consultationText,
+      patientDetails,
+    )
 }

--- a/src/components/consultation-pad-contents/consultation-pad-contents.test.tsx
+++ b/src/components/consultation-pad-contents/consultation-pad-contents.test.tsx
@@ -8,13 +8,21 @@ import {
 import SocketConnection from '../../utils/socket-connection/socket-connection'
 import {mockConceptResponse} from '../../__mocks__/conceptResponse.mock'
 import {mockObsResponse} from '../../__mocks__/obsResponse.mock'
-import {customVisitUrl} from '../../utils/constants'
-
+import {
+  consultationEncounterTypeUrl,
+  consultationNotesConceptUrl,
+  visitUrl,
+  encounterUrl,
+  saveNotesUrl,
+  unknownEncounterRoleUrl,
+} from '../../utils/constants'
+import {mockVisitResponseWithActiveEncounter} from '../../__mocks__/activeVisitWithActiveEncounters.mock'
 import {mockVisitResponseWithInactiveEncounter} from '../../__mocks__/activeVisitWithInactiveEncounters.mock'
 import {ConsultationPadContents} from './consultation-pad-contents'
 import {mockVisitResponseWithNoEncounter} from '../../__mocks__/activeVisitWithNoEncounter.mock'
+import {mockConsultationEncounterTypeResponse} from '../../__mocks__/encounterTypeResponse.mock'
+import {mockConsultationEncounterRoleResopnse} from '../../__mocks__/encounterRoleResponse.mock'
 import {mockVisitResponseWithActiveEncounterWithoutConsultationObs} from '../../__mocks__/activeVisitWithActiveEncountersAndWithoutConsultationObs.mock'
-import {mockVisitResponseWithActiveEncounter} from '../../__mocks__/activeVisitWithActiveEncounters.mock'
 import {updateObsResponse} from '../../__mocks__/updateObsResponse.mock'
 
 jest.mock('../../utils/socket-connection/socket-connection')
@@ -29,6 +37,7 @@ describe('Consultation Pad Contents', () => {
       patientUuid: 'abc',
       locationUuid: 'def',
       isActiveVisit: true,
+      providerUuid: '',
     }
 
     const value = {
@@ -69,6 +78,7 @@ describe('Consultation Pad Contents', () => {
       patientUuid: 'abc',
       locationUuid: 'def',
       isActiveVisit: true,
+      providerUuid: '',
     }
 
     const value = {
@@ -113,6 +123,7 @@ describe('Consultation Pad Contents', () => {
       patientUuid: 'abc',
       locationUuid: 'def',
       isActiveVisit: true,
+      providerUuid: '',
     }
 
     const value = {
@@ -163,6 +174,7 @@ describe('Consultation Pad Contents', () => {
       patientUuid: 'abc',
       locationUuid: 'def',
       isActiveVisit: true,
+      providerUuid: '',
     }
 
     const value = {
@@ -221,6 +233,7 @@ describe('Consultation Pad Contents', () => {
       patientUuid: 'abc',
       locationUuid: 'def',
       isActiveVisit: true,
+      providerUuid: '',
     }
 
     const value = {
@@ -279,6 +292,7 @@ describe('Consultation Pad Contents', () => {
       patientUuid: 'abc',
       locationUuid: 'def',
       isActiveVisit: true,
+      providerUuid: '',
     }
 
     const value = {
@@ -315,6 +329,7 @@ describe('Consultation Pad Contents', () => {
       patientUuid: 'abc',
       locationUuid: 'def',
       isActiveVisit: true,
+      providerUuid: '',
     }
 
     const value = {
@@ -372,112 +387,6 @@ describe('Consultation Pad Contents', () => {
     ).toBeEnabled()
   })
 
-  it('should not save consultation notes when clicked on save button and active consultation encounter is not present', async () => {
-    const mockSocketConnection = {
-      handleStart: jest.fn(),
-      handleStop: jest.fn(),
-    }
-    ;(SocketConnection as jest.Mock).mockImplementation(
-      () => mockSocketConnection,
-    )
-    global.fetch = jest.fn().mockImplementation()
-    const mockFetch = global.fetch as jest.Mock
-    mockFetch.mockResolvedValue({
-      json: () => mockVisitResponseWithInactiveEncounter,
-      ok: true,
-    })
-
-    const patientDetails: PatientDetails = {
-      patientUuid: 'dc9444c6-ad55-4200-b6e9-407e025eb948',
-      locationUuid: 'baf7bd38-d225-11e4-9c67-080027b662ec',
-      isActiveVisit: true,
-    }
-    const value = {
-      patientDetails: patientDetails,
-      savedConsultationNotes: '',
-      setSavedConsultationNotes: jest.fn(),
-    }
-
-    render(
-      <ConsultationContext.Provider value={value}>
-        <ConsultationPadContents
-          closeConsultationPad={handleClose}
-          consultationText={'Consultation Notes'}
-          setConsultationText={setConsultationText}
-        />
-      </ConsultationContext.Provider>,
-    )
-
-    expect(
-      screen.getByRole('button', {
-        name: /Save/i,
-      }),
-    ).toBeEnabled()
-
-    await userEvent.click(
-      screen.getByRole('button', {
-        name: /Save/i,
-      }),
-    )
-    expect(fetch).toBeCalledTimes(1)
-    expect(mockFetch.mock.calls[0][0]).toBe(
-      customVisitUrl(patientDetails.patientUuid, patientDetails.locationUuid),
-    )
-  })
-
-  it('should not save consultation notes when clicked on save button and consultation encounter is not present', async () => {
-    const mockSocketConnection = {
-      handleStart: jest.fn(),
-      handleStop: jest.fn(),
-    }
-    ;(SocketConnection as jest.Mock).mockImplementation(
-      () => mockSocketConnection,
-    )
-    global.fetch = jest.fn().mockImplementation()
-    const mockFetch = global.fetch as jest.Mock
-    mockFetch.mockResolvedValue({
-      json: () => mockVisitResponseWithNoEncounter,
-      ok: true,
-    })
-
-    const patientDetails: PatientDetails = {
-      patientUuid: 'dc9444c6-ad55-4200-b6e9-407e025eb948',
-      locationUuid: 'baf7bd38-d225-11e4-9c67-080027b662ec',
-      isActiveVisit: true,
-    }
-
-    const value = {
-      patientDetails: patientDetails,
-      savedConsultationNotes: '',
-      setSavedConsultationNotes: jest.fn(),
-    }
-    render(
-      <ConsultationContext.Provider value={value}>
-        <ConsultationPadContents
-          closeConsultationPad={handleClose}
-          consultationText={'Consultation Notes'}
-          setConsultationText={setConsultationText}
-        />
-      </ConsultationContext.Provider>,
-    )
-
-    expect(
-      screen.getByRole('button', {
-        name: /Save/i,
-      }),
-    ).toBeEnabled()
-
-    await userEvent.click(
-      screen.getByRole('button', {
-        name: /Save/i,
-      }),
-    )
-    expect(fetch).toBeCalledTimes(1)
-    expect(mockFetch.mock.calls[0][0]).toBe(
-      customVisitUrl(patientDetails.patientUuid, patientDetails.locationUuid),
-    )
-  })
-
   it('should save consultation notes and create new obs on click of save button when active consultation encounter is present and consultation obs is not present', async () => {
     global.fetch = jest.fn().mockImplementation()
 
@@ -496,17 +405,17 @@ describe('Consultation Pad Contents', () => {
         ok: true,
       })
 
-    const setSavedConsultationNotes = jest.fn()
     const patientDetails: PatientDetails = {
       patientUuid: 'dc9444c6-ad55-4200-b6e9-407e025eb948',
       locationUuid: 'baf7bd38-d225-11e4-9c67-080027b662ec',
       isActiveVisit: true,
+      providerUuid: '',
     }
 
     const value = {
-      patientDetails: patientDetails,
+      patientDetails,
       savedConsultationNotes: '',
-      setSavedConsultationNotes: setSavedConsultationNotes,
+      setSavedConsultationNotes: jest.fn(),
     }
     const consultationText = 'Consultation Notes'
 
@@ -538,12 +447,14 @@ describe('Consultation Pad Contents', () => {
 
     expect(fetch).toBeCalledTimes(3)
     expect(visiturl).toBe(
-      customVisitUrl(patientDetails.patientUuid, patientDetails.locationUuid),
+      visitUrl(patientDetails.patientUuid, patientDetails.locationUuid),
     )
-    expect(conceptUrl).toBe('/openmrs/ws/rest/v1/concept?q="Consultation Note')
-    expect(obsUrl).toBe('/openmrs/ws/rest/v1/obs')
+    expect(conceptUrl).toBe(consultationNotesConceptUrl)
+    expect(obsUrl).toBe(saveNotesUrl)
     expect(obsJsonBody.value).toBe('Consultation Notes')
-    expect(setSavedConsultationNotes).toHaveBeenCalledWith(consultationText)
+    expect(value.setSavedConsultationNotes).toHaveBeenCalledWith(
+      consultationText,
+    )
   })
 
   it('should save consultation notes and update the obs on click of save button when active consultation encounter and consultation obs is already present', async () => {
@@ -560,17 +471,17 @@ describe('Consultation Pad Contents', () => {
         ok: true,
       })
 
-    const setSavedConsultationNotes = jest.fn()
     const patientDetails: PatientDetails = {
       patientUuid: 'dc9444c6-ad55-4200-b6e9-407e025eb948',
       locationUuid: 'baf7bd38-d225-11e4-9c67-080027b662ec',
       isActiveVisit: true,
+      providerUuid: '',
     }
 
     const value = {
-      patientDetails: patientDetails,
+      patientDetails,
       savedConsultationNotes: '',
-      setSavedConsultationNotes: setSavedConsultationNotes,
+      setSavedConsultationNotes: jest.fn(),
     }
     const consultationText = 'Consultation Notes'
 
@@ -602,13 +513,15 @@ describe('Consultation Pad Contents', () => {
 
     expect(fetch).toBeCalledTimes(2)
     expect(visiturl).toBe(
-      customVisitUrl(patientDetails.patientUuid, patientDetails.locationUuid),
+      visitUrl(patientDetails.patientUuid, patientDetails.locationUuid),
     )
     expect(updateObsUrl).toBe(
       '/openmrs/ws/rest/v1/obs/8dd4d632-ec99-4056-b6dc-d489f1dc5f30',
     )
     expect(obsJsonBody.value).toBe('Consultation Notes')
-    expect(setSavedConsultationNotes).toHaveBeenCalledWith(consultationText)
+    expect(value.setSavedConsultationNotes).toHaveBeenCalledWith(
+      consultationText,
+    )
   })
 
   it('should update the consultation notes when user is typing manually on consultation pad', () => {
@@ -627,10 +540,11 @@ describe('Consultation Pad Contents', () => {
       patientUuid: 'dc9444c6-ad55-4200-b6e9-407e025eb948',
       locationUuid: 'baf7bd38-d225-11e4-9c67-080027b662ec',
       isActiveVisit: true,
+      providerUuid: '',
     }
 
     const value = {
-      patientDetails: patientDetails,
+      patientDetails,
       savedConsultationNotes: '',
       setSavedConsultationNotes: jest.fn(),
     }
@@ -655,5 +569,175 @@ describe('Consultation Pad Contents', () => {
     })
 
     expect(consultationText).toBe('Consultation')
+  })
+
+  it('should create encounter with observation on click of save button when consultation encounter is not present', async () => {
+    const mockSocketConnection = {
+      handleStart: jest.fn(),
+      handleStop: jest.fn(),
+    }
+    ;(SocketConnection as jest.Mock).mockImplementation(
+      () => mockSocketConnection,
+    )
+    global.fetch = jest.fn().mockImplementation()
+    const mockFetch = global.fetch as jest.Mock
+    mockFetch
+      .mockResolvedValueOnce({
+        json: () => mockVisitResponseWithNoEncounter,
+        ok: true,
+      })
+      .mockResolvedValueOnce({
+        json: () => mockConsultationEncounterTypeResponse,
+        ok: true,
+      })
+      .mockResolvedValueOnce({
+        json: () => mockConsultationEncounterRoleResopnse,
+        ok: true,
+      })
+      .mockResolvedValueOnce({
+        json: () => mockConceptResponse,
+        ok: true,
+      })
+      .mockResolvedValue({
+        json: () => {
+          // do nothing
+        },
+        ok: true,
+      })
+
+    const patientDetails: PatientDetails = {
+      patientUuid: 'dc9444c6-ad55-4200-b6e9-407e025eb948',
+      locationUuid: 'baf7bd38-d225-11e4-9c67-080027b662ec',
+      isActiveVisit: true,
+      providerUuid: 'c1c26908-3f10-11e4-adec-0800271c1b75',
+    }
+
+    const value = {
+      patientDetails,
+      savedConsultationNotes: '',
+      setSavedConsultationNotes: jest.fn(),
+    }
+
+    render(
+      <ConsultationContext.Provider value={value}>
+        <ConsultationPadContents
+          closeConsultationPad={handleClose}
+          consultationText={'Consultation Notes'}
+          setConsultationText={setConsultationText}
+        />
+      </ConsultationContext.Provider>,
+    )
+
+    expect(
+      screen.getByRole('button', {
+        name: /Save/i,
+      }),
+    ).toBeEnabled()
+
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /Save/i,
+      }),
+    )
+    expect(fetch).toBeCalledTimes(5)
+    const mockVisitUrl = mockFetch.mock.calls[0][0]
+    const mockEncounterTypeUrl = mockFetch.mock.calls[1][0]
+    const mockEncounterRoleurl = mockFetch.mock.calls[2][0]
+    const mockConceptUrl = mockFetch.mock.calls[3][0]
+    const mockEncounterUrl = mockFetch.mock.calls[4][0]
+    const mockEncounterRequestBody = JSON.parse(mockFetch.mock.calls[4][1].body)
+    expect(mockVisitUrl).toBe(
+      visitUrl(patientDetails.patientUuid, patientDetails.locationUuid),
+    )
+    expect(mockEncounterTypeUrl).toBe(consultationEncounterTypeUrl)
+    expect(mockEncounterRoleurl).toBe(unknownEncounterRoleUrl)
+    expect(mockConceptUrl).toBe(consultationNotesConceptUrl)
+    expect(mockEncounterUrl).toBe(encounterUrl)
+    expect(mockEncounterRequestBody.obs[0].value).toBe('Consultation Notes')
+  })
+
+  it('should create encounter with observation when clicked on save button and no active consultation encounter is present', async () => {
+    const mockSocketConnection = {
+      handleStart: jest.fn(),
+      handleStop: jest.fn(),
+    }
+    ;(SocketConnection as jest.Mock).mockImplementation(
+      () => mockSocketConnection,
+    )
+    global.fetch = jest.fn().mockImplementation()
+    const mockFetch = global.fetch as jest.Mock
+    mockFetch
+      .mockResolvedValueOnce({
+        json: () => mockVisitResponseWithInactiveEncounter,
+        ok: true,
+      })
+      .mockResolvedValueOnce({
+        json: () => mockConsultationEncounterTypeResponse,
+        ok: true,
+      })
+      .mockResolvedValueOnce({
+        json: () => mockConsultationEncounterRoleResopnse,
+        ok: true,
+      })
+      .mockResolvedValueOnce({
+        json: () => mockConceptResponse,
+        ok: true,
+      })
+      .mockResolvedValue({
+        json: () => {
+          // do nothing
+        },
+        ok: true,
+      })
+
+    const patientDetails: PatientDetails = {
+      patientUuid: 'dc9444c6-ad55-4200-b6e9-407e025eb948',
+      locationUuid: 'baf7bd38-d225-11e4-9c67-080027b662ec',
+      isActiveVisit: true,
+      providerUuid: 'c1c26908-3f10-11e4-adec-0800271c1b75',
+    }
+
+    const value = {
+      patientDetails,
+      savedConsultationNotes: '',
+      setSavedConsultationNotes: jest.fn(),
+    }
+
+    render(
+      <ConsultationContext.Provider value={value}>
+        <ConsultationPadContents
+          closeConsultationPad={handleClose}
+          consultationText={'Consultation Notes'}
+          setConsultationText={setConsultationText}
+        />
+      </ConsultationContext.Provider>,
+    )
+
+    expect(
+      screen.getByRole('button', {
+        name: /Save/i,
+      }),
+    ).toBeEnabled()
+
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /Save/i,
+      }),
+    )
+    expect(fetch).toBeCalledTimes(5)
+    const mockVisitUrl = mockFetch.mock.calls[0][0]
+    const mockEncounterTypeUrl = mockFetch.mock.calls[1][0]
+    const mockEncounterRoleurl = mockFetch.mock.calls[2][0]
+    const mockConceptUrl = mockFetch.mock.calls[3][0]
+    const mockEncounterUrl = mockFetch.mock.calls[4][0]
+    const mockEncounterRequestBody = JSON.parse(mockFetch.mock.calls[4][1].body)
+    expect(mockVisitUrl).toBe(
+      visitUrl(patientDetails.patientUuid, patientDetails.locationUuid),
+    )
+    expect(mockEncounterTypeUrl).toBe(consultationEncounterTypeUrl)
+    expect(mockEncounterRoleurl).toBe(unknownEncounterRoleUrl)
+    expect(mockConceptUrl).toBe(consultationNotesConceptUrl)
+    expect(mockEncounterUrl).toBe(encounterUrl)
+    expect(mockEncounterRequestBody.obs[0].value).toBe('Consultation Notes')
   })
 })

--- a/src/components/consultation-pad-contents/consultation-pad-contents.test.tsx
+++ b/src/components/consultation-pad-contents/consultation-pad-contents.test.tsx
@@ -533,7 +533,6 @@ describe('Consultation Pad Contents', () => {
       () => mockSocketConnection,
     )
     let consultationText = ''
-    const setConsultationText = jest.fn()
     setConsultationText.mockImplementation(value => (consultationText = value))
 
     const patientDetails: PatientDetails = {
@@ -599,9 +598,7 @@ describe('Consultation Pad Contents', () => {
         ok: true,
       })
       .mockResolvedValue({
-        json: () => {
-          // do nothing
-        },
+        json: () => ({}),
         ok: true,
       })
 
@@ -684,9 +681,7 @@ describe('Consultation Pad Contents', () => {
         ok: true,
       })
       .mockResolvedValue({
-        json: () => {
-          // do nothing
-        },
+        json: () => ({}),
         ok: true,
       })
 

--- a/src/components/consultation-pad/consultation-pad.test.tsx
+++ b/src/components/consultation-pad/consultation-pad.test.tsx
@@ -17,6 +17,7 @@ describe('Consultation Pad', () => {
       patientUuid: 'abc',
       locationUuid: 'def',
       isActiveVisit: true,
+      providerUuid: '',
     }
 
     const value = {
@@ -57,6 +58,7 @@ describe('Consultation Pad', () => {
       patientUuid: 'abc',
       locationUuid: 'def',
       isActiveVisit: true,
+      providerUuid: '',
     }
 
     const value = {
@@ -116,6 +118,7 @@ describe('Consultation Pad', () => {
       patientUuid: 'abc',
       locationUuid: 'def',
       isActiveVisit: true,
+      providerUuid: '',
     }
 
     const value = {

--- a/src/context/consultation-context.tsx
+++ b/src/context/consultation-context.tsx
@@ -1,6 +1,5 @@
 import React, {useEffect, useRef, useState} from 'react'
-import {getApiCall} from '../utils/api-utils'
-import {visitUrl, sessionUrl} from '../utils/constants'
+import {getActiveVisitResponse, getProviderUuid} from '../utils/api-utils'
 import {
   getActiveConsultationEncounter,
   getConsultationObs,
@@ -26,11 +25,6 @@ export interface ConsultationContextProps {
 export const ConsultationContext =
   React.createContext<ConsultationContextProps>(null)
 
-async function fetchActiveVisitResponse(patiendId, locationId) {
-  const activeVisitResponse = await getApiCall(visitUrl(patiendId, locationId))
-  return activeVisitResponse
-}
-
 export function usePatientDetails() {
   const context = React.useContext(ConsultationContext)
   return context.patientDetails
@@ -42,11 +36,6 @@ export function useSavedConsultationNotes() {
     savedConsultationNotes: context.savedConsultationNotes,
     setSavedConsultationNotes: context.setSavedConsultationNotes,
   }
-}
-
-async function getProviderUuid() {
-  const response = await getApiCall(sessionUrl)
-  return response?.currentProvider?.uuid
 }
 
 function ConsultationContextProvider({children}) {
@@ -71,10 +60,10 @@ function ConsultationContextProvider({children}) {
     }
   }
 
-  const updatePatientDetails = async (patientUuid, locationUuid) => {
-    const activeVisitResponse = await fetchActiveVisitResponse(
-      patientUuid,
-      locationUuid,
+  const updatePatientDetails = async (patientId, locationId) => {
+    const activeVisitResponse = await getActiveVisitResponse(
+      patientId,
+      locationId,
     )
     const isActiveVisit = activeVisitResponse?.results?.length > 0
 

--- a/src/context/consultation-context.tsx
+++ b/src/context/consultation-context.tsx
@@ -62,9 +62,10 @@ function ConsultationContextProvider({children}) {
 
     if (consultationActiveEncounter) {
       const consultationObs = getConsultationObs(consultationActiveEncounter)
-      const matcher = new RegExp(`Consultation Note: (?<notes>.*)`)
       if (consultationObs) {
-        const savedData = matcher.exec(consultationObs.display).groups?.notes
+        const savedData = consultationObs.display.match(
+          /Consultation Note: (?<notes>.*)/,
+        )[1]
         setSavedConsultationNotes(savedData)
       }
     }

--- a/src/utils/api-utils.ts
+++ b/src/utils/api-utils.ts
@@ -1,11 +1,11 @@
+import {sessionUrl, visitUrl} from './constants'
+
 export const getApiCall = async url => {
   const response = await fetch(url, {
     method: 'GET',
   })
 
-  if (response.ok) {
-    return response.json()
-  }
+  return response.json()
 }
 export const postApiCall = (url, data) => {
   return fetch(url, {
@@ -15,4 +15,14 @@ export const postApiCall = (url, data) => {
     },
     body: JSON.stringify(data),
   })
+}
+
+export async function getActiveVisitResponse(patiendId, locationId) {
+  const activeVisitResponse = await getApiCall(visitUrl(patiendId, locationId))
+  return activeVisitResponse
+}
+
+export async function getProviderUuid() {
+  const response = await getApiCall(sessionUrl)
+  return response?.currentProvider?.uuid
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -2,7 +2,14 @@ export const streamingURL = location.origin
 export const language = 'en'
 export const bahmniSaveButtonResponseTime = 3000
 export const saveNotesUrl = '/openmrs/ws/rest/v1/obs'
-export const conceptUrl = '/openmrs/ws/rest/v1/concept?q="Consultation Note'
-export const customVisitUrl = (patientId, locationId) =>
+export const visitUrl = (patientId, locationId) =>
   `/openmrs/ws/rest/v1/visit?includeInactive=false&patient=${patientId}&location=${locationId}&v=custom:(uuid,visitType,startDatetime,stopDatetime,encounters)`
 export const updateObsUrl = obsUuid => `/openmrs/ws/rest/v1/obs/${obsUuid}`
+export const consultationEncounterTypeUrl =
+  '/openmrs/ws/rest/v1/encountertype?q=Consultation'
+export const unknownEncounterRoleUrl =
+  '/openmrs/ws/rest/v1/encounterrole?q=unknown'
+export const consultationNotesConceptUrl =
+  '/openmrs/ws/rest/v1/concept?q="Consultation Note"'
+export const encounterUrl = '/openmrs/ws/rest/v1/encounter'
+export const sessionUrl = '/openmrs/ws/rest/v1/session?v=full'


### PR DESCRIPTION
## Requirements

- [x] This PR has a proper title that briefly describes the work done
- [x] I have squashed / amended the comments to make it more redable
- [x] I have included link to all the JIRA ticket('s)
- [x] I wrote the code as a pair or atleast performed a self-review of my own code
- [ ] I have updated the documentation on [Bahmni Wiki](https://bahmni.atlassian.net/wiki/spaces/BAH/overview) or [README](https://github.com/Bahmni/speech-assistant-frontend/blob/main/README.md) (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Summary
To save the consultation notes, we need to save it against a consultation encounter type. Here, we can have an active encounter or an expired encounter
In case of active encounter → We need to associate the consultation notes with the active consultation encounter ( This story is being played)
In case of no present active consultation encounter → We need to create a new encounter.
In the case where we need to create a new encounter, we need the encounter role, which is a mandatory field
In Bahmni, the encouter role is hardcoded and the value of the UUID is “unknown” as seen in the database


## JIRA tickets
https://bahmni.atlassian.net/browse/BAH-2153
