### PR TITLE
BAH-2394 | Fetching saved notes in the consultation notes box

### DIFF
--- a/src/components/consultation-pad-contents/consultation-pad-contents.test.tsx
+++ b/src/components/consultation-pad-contents/consultation-pad-contents.test.tsx
@@ -311,13 +311,26 @@ describe('Consultation Pad Contents', () => {
     ;(SocketConnection as jest.Mock).mockImplementation(
       () => mockSocketConnection,
     )
+    const mockPatientDetails: PatientDetails = {
+      patientUuid: 'abc',
+      locationUuid: 'def',
+      isActiveVisit: true,
+    }
+
+    const value = {
+      patientDetails: mockPatientDetails,
+      savedConsultationNotes: '',
+      setSavedConsultationNotes: jest.fn(),
+    }
     render(
-      <ConsultationPadContents
-        closeConsultationPad={handleClose}
-        consultationText={'consultationText'}
-        setConsultationText={setConsultationText}
-        setSavedNotes={setSavedNotes}
-      />,
+      <ConsultationContext.Provider value={value}>
+        <ConsultationPadContents
+          closeConsultationPad={handleClose}
+          consultationText={'consultationText'}
+          setConsultationText={setConsultationText}
+        />
+        ,
+      </ConsultationContext.Provider>,
     )
 
     const mockOnRecording = (SocketConnection as jest.Mock).mock.calls[0][2]


### PR DESCRIPTION
## Requirements

- [X] This PR has a proper title that briefly describes the work done
- [X] I have squashed / amended the comments to make it more readable
- [X] I have included link to all the JIRA ticket('s)
- [X] I wrote the code as a pair or atleast performed a self-review of my own code
- [ ] I have updated the documentation on [Bahmni Wiki](https://bahmni.atlassian.net/wiki/spaces/BAH/overview) or [README](https://github.com/Bahmni/speech-assistant-frontend/blob/main/README.md) (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## Summary
In case the doctor had saved notes for the patient during the ongoing encounter , then the notes should be reflected in the consultation box, so that the doctor can make changes to it and update. Right now, the notes once saved are not fetched in the consultation box and therefore the doctor is unable to make any changes to the notes, but can create a new entry.


## JIRA tickets
https://bahmni.atlassian.net/browse/BAH-2394
